### PR TITLE
Add basic i18n setup with Spanish default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .env
+.next

--- a/next.config.js
+++ b/next.config.js
@@ -3,13 +3,17 @@ const nextConfig = {
   reactStrictMode: true,
   //  basePath: '/prodweb',
   swcMinify: true,
+  i18n: {
+    locales: ['en', 'es'],
+    defaultLocale: 'es'
+  },
   async rewrites() {
     return [
       {
         source: '/api/backend/:path*',
         destination: 'http://localhost/ProdBackendTest/api/:path*', // URL de tu backend
       },
-      
+
       {
         source: '/api/:path*',
         destination: '/api/:path*' // Deja las rutas locales intactas

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -4,6 +4,7 @@ import { LayoutProvider } from '../layout/context/layoutcontext';
 import Layout from '../layout/layout';
 import { Toast } from 'primereact/toast';
 import ProductionGuard from '../components/ProductionGuard/ProductionGuard'; // ✅ Importa aquí
+import { I18nProvider } from '../utilities/i18n';
 
 import 'primereact/resources/primereact.css';
 import 'primeflex/primeflex.css';
@@ -48,21 +49,25 @@ export default function MyApp({ Component, pageProps }) {
             return null;
         }
         return (
-            <LayoutProvider>
-                <Toast ref={toast} position="top-right" />
-                <ProductionGuard /> {/* ✅ Se renderiza aquí */}
-                {Component.getLayout(<Component {...pageProps} />)}
-            </LayoutProvider>
+            <I18nProvider>
+                <LayoutProvider>
+                    <Toast ref={toast} position="top-right" />
+                    <ProductionGuard /> {/* ✅ Se renderiza aquí */}
+                    {Component.getLayout(<Component {...pageProps} />)}
+                </LayoutProvider>
+            </I18nProvider>
         );
     } else {
         return (
-            <LayoutProvider>
-                <Layout>
-                    <Toast ref={toast} position="top-right" />
-                    <ProductionGuard /> {/* ✅ También aquí */}
-                    {showChild && <Component {...pageProps} />}
-                </Layout>
-            </LayoutProvider>
+            <I18nProvider>
+                <LayoutProvider>
+                    <Layout>
+                        <Toast ref={toast} position="top-right" />
+                        <ProductionGuard /> {/* ✅ También aquí */}
+                        {showChild && <Component {...pageProps} />}
+                    </Layout>
+                </LayoutProvider>
+            </I18nProvider>
         );
     }
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -9,38 +9,49 @@ import { LayoutContext } from '../layout/context/layoutcontext';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { Toast } from 'primereact/toast';
-const lineData = {
-    labels: ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
-    datasets: [
-        {
-            label: 'First Dataset',
-            data: [65, 59, 80, 81, 56, 55, 40],
-            fill: false,
-            backgroundColor: '#2f4860',
-            borderColor: '#2f4860',
-            tension: 0.4
-        },
-        {
-            label: 'Second Dataset',
-            data: [28, 48, 40, 19, 86, 27, 90],
-            fill: false,
-            backgroundColor: '#00bb7e',
-            borderColor: '#00bb7e',
-            tension: 0.4
-        }
-    ]
-};
+import { useTranslation } from '../utilities/i18n';
 
 const Dashboard = () => {
+    const { t } = useTranslation();
     const [products, setProducts] = useState(null);
     const menu1 = useRef(null);
     const menu2 = useRef(null);
-    const [lineOptions, setLineOptions] = useState(null);    
-    const [logged, setLogged] = useState('');    
+    const [lineOptions, setLineOptions] = useState(null);
+    const [logged, setLogged] = useState('');
     const { layoutConfig } = useContext(LayoutContext);
-   
+
     const toast = useRef(null);
     const router = useRouter();
+
+    const lineData = {
+        labels: [
+            t('months.january'),
+            t('months.february'),
+            t('months.march'),
+            t('months.april'),
+            t('months.may'),
+            t('months.june'),
+            t('months.july')
+        ],
+        datasets: [
+            {
+                label: t('dataset.first'),
+                data: [65, 59, 80, 81, 56, 55, 40],
+                fill: false,
+                backgroundColor: '#2f4860',
+                borderColor: '#2f4860',
+                tension: 0.4
+            },
+            {
+                label: t('dataset.second'),
+                data: [28, 48, 40, 19, 86, 27, 90],
+                fill: false,
+                backgroundColor: '#00bb7e',
+                borderColor: '#00bb7e',
+                tension: 0.4
+            }
+        ]
+    };
 
     const applyLightTheme = () => {
         const lineOptions = {
@@ -159,12 +170,12 @@ const Dashboard = () => {
             <div className="col-12 ">
                 <div className="card mb-0">
                     <div className="flex justify-content-between mb-3">
-                        <h1>Welcome {logged}</h1>
+                        <h1>{t('welcome', { name: logged })}</h1>
                     </div>
-                    <span className="text-green-500 font-medium">Today </span>
-                    <span className="text-500">is Happy</span>
+                    <span className="text-green-500 font-medium">{t('today')} </span>
+                    <span className="text-500">{t('isHappy')}</span>
 
-                    <div className="text-blue-500 font-medium mt-5" onClick={()=>logout()}>logout </div>
+                    <div className="text-blue-500 font-medium mt-5" onClick={() => logout()}>{t('logout')} </div>
 
                 </div>
             </div>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,0 +1,19 @@
+{
+  "welcome": "Welcome {{name}}",
+  "today": "Today",
+  "isHappy": "is Happy",
+  "logout": "logout",
+  "dataset": {
+    "first": "First Dataset",
+    "second": "Second Dataset"
+  },
+  "months": {
+    "january": "January",
+    "february": "February",
+    "march": "March",
+    "april": "April",
+    "may": "May",
+    "june": "June",
+    "july": "July"
+  }
+}

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -1,0 +1,19 @@
+{
+  "welcome": "Bienvenido {{name}}",
+  "today": "Hoy",
+  "isHappy": "está feliz",
+  "logout": "Cerrar sesión",
+  "dataset": {
+    "first": "Primer Conjunto",
+    "second": "Segundo Conjunto"
+  },
+  "months": {
+    "january": "Enero",
+    "february": "Febrero",
+    "march": "Marzo",
+    "april": "Abril",
+    "may": "Mayo",
+    "june": "Junio",
+    "july": "Julio"
+  }
+}

--- a/utilities/i18n.js
+++ b/utilities/i18n.js
@@ -1,0 +1,28 @@
+import { createContext, useContext } from 'react';
+import { useRouter } from 'next/router';
+import en from '../public/locales/en/common.json';
+import es from '../public/locales/es/common.json';
+
+const resources = { en, es };
+const I18nContext = createContext({ t: (key) => key });
+
+export const I18nProvider = ({ children }) => {
+  const { locale = 'es' } = useRouter();
+  const dictionary = resources[locale] || resources['es'];
+
+  const t = (key, options = {}) => {
+    const value = key.split('.').reduce((obj, k) => (obj && obj[k]) ? obj[k] : key, dictionary);
+    return Object.keys(options).reduce(
+      (str, param) => str.replace(`{{${param}}}`, options[param]),
+      value
+    );
+  };
+
+  return (
+    <I18nContext.Provider value={{ t }}>
+      {children}
+    </I18nContext.Provider>
+  );
+};
+
+export const useTranslation = () => useContext(I18nContext);


### PR DESCRIPTION
## Summary
- configure Next.js i18n with Spanish as default
- add simple translation provider and sample dictionaries
- translate index page strings to use `t()`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b4a2fe4d54832596c1f90a3f03a303