### PR TITLE
feat: add topbar language selector

### DIFF
--- a/layout/AppTopbar.js
+++ b/layout/AppTopbar.js
@@ -5,6 +5,7 @@ import { classNames } from 'primereact/utils';
 import React, { forwardRef, useContext, useImperativeHandle, useRef, useState, useEffect } from 'react';
 import { LayoutContext } from './context/layoutcontext';
 import { Button } from 'primereact/button';
+import { Dropdown } from 'primereact/dropdown';
 import 'primereact/resources/themes/saga-blue/theme.css';
 import 'primereact/resources/primereact.min.css';
 import 'primeicons/primeicons.css';
@@ -13,7 +14,7 @@ import ProductionInfoModal from '../components/ProductionInfoModal/ProductionInf
 import { Toast } from 'primereact/toast';
 
 const AppTopbar = forwardRef((props, ref) => {
-    const { layoutConfig, layoutState, onMenuToggle, showProfileSidebar } = useContext(LayoutContext);
+    const { layoutConfig, layoutState, onMenuToggle, showProfileSidebar, language, setLanguage } = useContext(LayoutContext);
     const menubuttonRef = useRef(null);
     const topbarmenuRef = useRef(null);
     const topbarmenubuttonRef = useRef(null);
@@ -167,6 +168,18 @@ const AppTopbar = forwardRef((props, ref) => {
         }
     }, [modalVisible]);
 
+    const languageOptions = [
+        { label: 'EN', value: 'EN' },
+        { label: 'ES', value: 'ES' }
+    ];
+
+    const onLanguageChange = (e) => {
+        setLanguage(e.value);
+        if (typeof window !== 'undefined') {
+            window.location.reload();
+        }
+    };
+
     return (
         <div className="layout-topbar" >
             <Toast ref={toast} position="top-right" style={{ marginTop: '60px', zIndex: 9999 }} />
@@ -205,6 +218,7 @@ const AppTopbar = forwardRef((props, ref) => {
                 <span className="header-item">{"Line: " + line}</span>
                 <span className="header-item">{"Shift: " + shift}</span>
                 <span className="header-item">{username}</span>
+                <Dropdown value={language} options={languageOptions} onChange={onLanguageChange} className="language-selector" />
                 <button type="button" className="p-link layout-topbar-button">
                     <i className="pi pi-user"></i>
                     <span>Profile</span>

--- a/layout/context/layoutcontext.js
+++ b/layout/context/layoutcontext.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 export const LayoutContext = React.createContext();
 
@@ -20,6 +20,21 @@ export const LayoutProvider = (props) => {
         staticMenuMobileActive: false,
         menuHoverActive: false
     });
+
+    const [language, setLanguage] = useState('EN');
+
+    useEffect(() => {
+        if (typeof window !== 'undefined') {
+            const storedLang = localStorage.getItem('language') || 'EN';
+            setLanguage(storedLang);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (typeof window !== 'undefined') {
+            localStorage.setItem('language', language);
+        }
+    }, [language]);
 
     const onMenuToggle = () => {
         if (isOverlay()) {
@@ -51,7 +66,9 @@ export const LayoutProvider = (props) => {
         layoutState,
         setLayoutState,
         onMenuToggle,
-        showProfileSidebar
+        showProfileSidebar,
+        language,
+        setLanguage
     };
 
     return <LayoutContext.Provider value={value}>{props.children}</LayoutContext.Provider>;

--- a/styles/layout/_topbar.scss
+++ b/styles/layout/_topbar.scss
@@ -176,3 +176,17 @@
 .header-item {
     margin-right: 10px; /* Ajusta el espaciado entre los elementos */
 }
+
+.language-selector {
+    width: 4rem;
+
+    .p-dropdown {
+        background: var(--surface-card);
+        border: 1px solid var(--surface-border);
+        color: var(--text-color);
+    }
+
+    .p-dropdown-trigger {
+        color: var(--primary-color);
+    }
+}


### PR DESCRIPTION
## Summary
- add EN/ES language dropdown to top bar
- persist language selection via LayoutContext and localStorage
- style language selector using palette variables

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b4a2ff58288325816e4cd786b56142