### PR TITLE
Use Next.js locale for language switch

### DIFF
--- a/layout/AppTopbar.js
+++ b/layout/AppTopbar.js
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { classNames } from 'primereact/utils';
 import React, { forwardRef, useContext, useImperativeHandle, useRef, useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
 import { LayoutContext } from './context/layoutcontext';
 import { Button } from 'primereact/button';
 import { Dropdown } from 'primereact/dropdown';
@@ -15,6 +16,7 @@ import { Toast } from 'primereact/toast';
 
 const AppTopbar = forwardRef((props, ref) => {
     const { layoutConfig, layoutState, onMenuToggle, showProfileSidebar, language, setLanguage } = useContext(LayoutContext);
+    const router = useRouter();
     const menubuttonRef = useRef(null);
     const topbarmenuRef = useRef(null);
     const topbarmenubuttonRef = useRef(null);
@@ -175,9 +177,7 @@ const AppTopbar = forwardRef((props, ref) => {
 
     const onLanguageChange = (e) => {
         setLanguage(e.value);
-        if (typeof window !== 'undefined') {
-            window.location.reload();
-        }
+        router.push(router.asPath, undefined, { locale: e.value.toLowerCase() });
     };
 
     return (

--- a/layout/context/layoutcontext.js
+++ b/layout/context/layoutcontext.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
 
 export const LayoutContext = React.createContext();
 
@@ -21,20 +22,12 @@ export const LayoutProvider = (props) => {
         menuHoverActive: false
     });
 
-    const [language, setLanguage] = useState('EN');
+    const { locale } = useRouter();
+    const [language, setLanguage] = useState(locale ? locale.toUpperCase() : 'EN');
 
     useEffect(() => {
-        if (typeof window !== 'undefined') {
-            const storedLang = localStorage.getItem('language') || 'EN';
-            setLanguage(storedLang);
-        }
-    }, []);
-
-    useEffect(() => {
-        if (typeof window !== 'undefined') {
-            localStorage.setItem('language', language);
-        }
-    }, [language]);
+        setLanguage(locale ? locale.toUpperCase() : 'EN');
+    }, [locale]);
 
     const onMenuToggle = () => {
         if (isOverlay()) {


### PR DESCRIPTION
## Summary
- Switch AppTopbar language control to Next.js locale routing
- Manage language from router locale instead of localStorage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(terminated after 10s; served Next.js app)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a7e56bd883259c4d79f0de5b08f2