### PR TITLE
feat: add i18n translations

### DIFF
--- a/components/ProductionOrderList/ProductionOrderList.jsx
+++ b/components/ProductionOrderList/ProductionOrderList.jsx
@@ -9,8 +9,10 @@ import { Dropdown } from 'primereact/dropdown';
 import { InputText } from 'primereact/inputtext';
 import { Card } from 'primereact/card';
 import { formatDate } from '../../utilities/formatDate'
+import { useTranslation } from '../../utilities/i18n';
 
 const ProductionOrders = ({ type }) => {
+  const { t } = useTranslation();
   const [pOrders, setPOrders] = useState([]);
   const [filteredOrders, setFilteredOrders] = useState([]);
   const [statusFilter, setStatusFilter] = useState('All');
@@ -18,10 +20,10 @@ const ProductionOrders = ({ type }) => {
   const [customerPOSearch, setCustomerPOSearch] = useState('');
 
   const statusOptions = [
-    { label: 'All', value: 'All' },
-    { label: 'Released', value: 'Released' },
-    { label: 'Open', value: 'Open' },
-    { label: 'Close', value: 'Close' },
+    { label: t('productionList.statusAll'), value: 'All' },
+    { label: t('productionList.statusReleased'), value: 'Released' },
+    { label: t('productionList.statusOpen'), value: 'Open' },
+    { label: t('productionList.statusClose'), value: 'Close' },
   ];
 
   useEffect(() => {
@@ -119,19 +121,19 @@ const ProductionOrders = ({ type }) => {
     <>
       <Card>
         <div style={styles.header}>
-          <h1 style={styles.title}>{type} Production Orders</h1>
+          <h1 style={styles.title}>{type} {t('productionList.orders')}</h1>
           <div style={styles.filters}>
             <Dropdown
               value={statusFilter}
               options={statusOptions}
               onChange={onStatusChange}
-              placeholder="Select a Status"
+              placeholder={t('productionList.selectStatus')}
               style={styles.dropdown}
             />
             <InputText
               value={customerPOSearch}
               onChange={onCustomerPOSearchChange}
-              placeholder="Search by Customer PO"
+              placeholder={t('productionList.searchCustomerPO')}
               style={styles.searchInput}
             />
           </div>
@@ -145,42 +147,42 @@ const ProductionOrders = ({ type }) => {
         >
           <Column
             body={linkTemplate}
-            header="Customer PO"
+            header={t('productionList.customerPO')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '30rem' }}
           />
           <Column
             field="Status"
-            header="Status"
+            header={t('productionList.status')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '15rem' }}
           />
           <Column
             field="ItemCode"
-            header="SKU"
+            header={t('productionList.sku')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '20rem' }}
           />
           <Column
             field="ProdName"
-            header="Product Description"
+            header={t('productionList.productDescription')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '60rem' }}
           />
           <Column
             field="DocNum"
-            header="Origin POs"
+            header={t('productionList.originPOs')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '15rem' }}
           />
           <Column
             field="PlannedQty"
-            header="Planned Quantity"
+            header={t('productionOrder.plannedQuantity')}
             body={(rowData) => `${parseFloat(rowData.PlannedQty).toFixed(0)} ${rowData.SalUnitMsr}`}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody1}
@@ -188,35 +190,35 @@ const ProductionOrders = ({ type }) => {
           />
           <Column
             body={infoMixes}
-            header="Mixes"
+            header={t('productionList.mixes')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '10rem' }}
           />
           <Column
             body={infoPallets}
-            header="Pallets"
+            header={t('productionList.pallets')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '10rem' }}
           />
           <Column
             body={dateTemplate}
-            header="Started Date"
+            header={t('productionList.startedDate')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '20rem' }}
           />
           <Column
             body={dateTemplateFinish}
-            header="Finish Date"
+            header={t('productionList.finishDate')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '20rem' }}
           />
           <Column
             body={dateTemplateDelivery}
-            header="Delivery Date"
+            header={t('productionList.deliveryDate')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '20rem' }}

--- a/components/Warning/Warning.jsx
+++ b/components/Warning/Warning.jsx
@@ -5,16 +5,18 @@ import { Dialog } from 'primereact/dialog';
 import { Button } from 'primereact/button';
 import { Message } from 'primereact/message';
 import { ProgressSpinner } from 'primereact/progressspinner';
+import { useTranslation } from '../../utilities/i18n';
 const WarningDialog = ({ visible, onHide, onConfirm, text, loading, setLoading }) => {
+    const { t } = useTranslation();
     const footer = (
         <div>
-            <Button label="Cancel" icon="pi pi-times" className="p-button-danger" onClick={onHide} />
-            <Button label="OK" icon="pi pi-check" className="p-button-success" onClick={onConfirm} />
+            <Button label={t('warningDialog.cancel')} icon="pi pi-times" className="p-button-danger" onClick={onHide} />
+            <Button label={t('warningDialog.ok')} icon="pi pi-check" className="p-button-success" onClick={onConfirm} />
         </div>
     );
 
     return (
-        <Dialog header="¡Warning!" visible={visible} style={{ width: '30vw' }} footer={footer} onHide={onHide}>
+        <Dialog header={t('warningDialog.title')} visible={visible} style={{ width: '30vw' }} footer={footer} onHide={onHide}>
             
             <div className="p-grid p-dir-col">
             {loading && (

--- a/pages/production/[id].jsx
+++ b/pages/production/[id].jsx
@@ -23,6 +23,7 @@ import combineDateAndTime from '../../utilities/functions';
 import substractTime from '../../utilities/timeBack'
 import { ProgressSpinner } from 'primereact/progressspinner';
 import formatNumber from '../../utilities/formatNumber';
+import { useTranslation } from '../../utilities/i18n';
 const ProductionOrder = () => {
 
   const router = useRouter();
@@ -44,7 +45,8 @@ const ProductionOrder = () => {
   const [restarTime, setRestarTime] = useState(null);
   const [enable, setEnable] = useState(false);
   const toast = useRef(null);
-  const [textWarning, setTextWarning] = useState('Are you sure you want to finalize the production? Once the Production Order is closed, you will no longer be able to add new mixes or receive finished goods. If you agree, click OK; otherwise, click Cancel');
+  const { t } = useTranslation();
+  const [textWarning, setTextWarning] = useState(t('productionPage.finalizeConfirmation'));
   const [isWarningVisible, setIsWarningVisible] = useState(false);
   const [isSaved, setIsSaved] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -115,8 +117,8 @@ const ProductionOrder = () => {
       if (!isValid) {
           toast.current.show({
               severity: 'warn',
-              summary: 'Warning',
-              detail: 'Some components have not been issued. Please review the components related to seasoning/oil.'
+              summary: t('warning'),
+              detail: t('productionPage.someComponentsNotIssued')
           });
       }
   
@@ -331,15 +333,15 @@ const ProductionOrder = () => {
       const result = await response.json();
 
       if (response.ok) {
-        toast.current.show({ severity: 'success', summary: 'Success', detail: 'Production paused successfully' });
+        toast.current.show({ severity: 'success', summary: t('success'), detail: t('productionPage.productionPaused') });
         setPauseTime(elapsedFormatted);
 
       } else {
-        toast.current.show({ severity: 'error', summary: 'Error', detail: result.message || 'An unexpected error occurred' });
+        toast.current.show({ severity: 'error', summary: t('error'), detail: result.message || t('productionPage.productionPauseFailed') });
       }
     } catch (error) {
       console.error('Error pausing production:', error);
-      toast.current.show({ severity: 'error', summary: 'Error', detail: 'Failed to pause production' });
+      toast.current.show({ severity: 'error', summary: t('error'), detail: t('productionPage.productionPauseFailed') });
     }
 
 
@@ -379,14 +381,14 @@ const ProductionOrder = () => {
         const result = await response.json();
 
         if (response.ok) {
-          toast.current.show({ severity: 'success', summary: 'Success', detail: 'Production resumed successfully' });
+          toast.current.show({ severity: 'success', summary: t('success'), detail: t('productionPage.productionResumed') });
 
         } else {
-          toast.current.show({ severity: 'error', summary: 'Error', detail: result.message || 'An unexpected error occurred' });
+          toast.current.show({ severity: 'error', summary: t('error'), detail: result.message || t('productionPage.productionResumeFailed') });
         }
       } catch (error) {
         console.error('Error resuming production:', error);
-        toast.current.show({ severity: 'error', summary: 'Error', detail: 'Failed to resume production' });
+        toast.current.show({ severity: 'error', summary: t('error'), detail: t('productionPage.productionResumeFailed') });
       }
 
       setRestarTime(substractTime(order[0].ConsumedTime))
@@ -429,13 +431,13 @@ const ProductionOrder = () => {
         const result = await response.json();
 
         if (response.ok) {
-          toast.current.show({ severity: 'success', summary: 'Success', detail: 'Production started successfully' });
+          toast.current.show({ severity: 'success', summary: t('success'), detail: t('productionPage.productionStarted') });
         } else {
-          toast.current.show({ severity: 'error', summary: 'Error', detail: result.message || 'An unexpected error occurred' });
+          toast.current.show({ severity: 'error', summary: t('error'), detail: result.message || t('productionPage.productionStartFailed') });
         }
       } catch (error) {
         console.error('Error starting production:', error);
-        toast.current.show({ severity: 'error', summary: 'Error', detail: 'Failed to start production' });
+        toast.current.show({ severity: 'error', summary: t('error'), detail: t('productionPage.productionStartFailed') });
       }
       finally {
         setLoadingStart(false)
@@ -484,12 +486,12 @@ const ProductionOrder = () => {
       await Promise.all(promises);
   
       // Mostrar un solo mensaje de éxito cuando todas las órdenes se hayan cerrado correctamente
-      toast.current.show({ severity: 'success', summary: 'Success', detail: 'All production orders closed successfully' });
+      toast.current.show({ severity: 'success', summary: t('success'), detail: t('productionPage.allOrdersClosed') });
   
       fetchOrder(); // Actualiza los datos después de cerrar las órdenes
     } catch (error) {
       console.error('Error closing production orders:', error);
-      toast.current.show({ severity: 'error', summary: 'Error', detail: 'Failed to close production orders' });
+      toast.current.show({ severity: 'error', summary: t('error'), detail: t('productionPage.closeOrdersFailed') });
     } finally {
       setLoading(false);
     }
@@ -675,7 +677,7 @@ const ProductionOrder = () => {
       
         showIssueDialog(order);
       } else {
-        toast.current.show({ severity: 'warn', summary: 'Warning', detail: 'There is not enough dough quantity to continue generating pallets. Please complete mixes.' });
+        toast.current.show({ severity: 'warn', summary: t('warning'), detail: t('productionPage.notEnoughDough') });
 
       }
     } else {
@@ -838,7 +840,7 @@ else
       <>
         {rowData.Type === 'PO' && (
           <Button
-            label={order[0].CloseDate || order[0].IsPaused === 'Y' ? "Review" : "Produce"}
+            label={order[0].CloseDate || order[0].IsPaused === 'Y' ? t('productionPage.review') : t('productionOrder.produce')}
             className="p-button-info"
             onClick={() => handleProduceClick(rowData)}
             disabled={order[0].CloseDate ? false : (!order[0].StartTime || order[0].CloseDate)}
@@ -846,13 +848,13 @@ else
           />
         )}
         {rowData.Type === 'Item' && (
-          <Button
-            label="Issue"
-            className="p-button-warning"
-            onClick={() => showIssueDialog(rowData)}
-            disabled={!order[0].StartTime || order[0].CloseDate}
-            rounded
-          />
+            <Button
+              label={t('productionOrder.issue')}
+              className="p-button-warning"
+              onClick={() => showIssueDialog(rowData)}
+              disabled={!order[0].StartTime || order[0].CloseDate}
+              rounded
+            />
         )}
       </>
     );
@@ -875,18 +877,18 @@ else
            
             <div><b>Product No.:</b> {order[0]?.ItemCode}</div>
             <div><b>Product Description:</b> {order[0]?.ProdName}</div>
-            {order[0]?.ParentOrKid==='Kid'&&order[0].ProduccionGO && <div><b>Planned Quantity:</b>  {formatNumber(Number(order[0]?.PlannedQty))} EA ({Math.ceil(formatNumber(Number(order[0]?.PlannedQty))/order[0].UndXPallet)} Pallets)</div>}
-            {order[0]?.ParentOrKid==='Parent'&&!order[0].ProduccionGO && <div><b>Planned Quantity:</b>  {formatNumber(Number(order[0]?.PlannedQty))} EA ({Math.ceil(formatNumber(Number(order[0]?.PlannedQty))/order[0].UndXPallet)} Pallets)</div>}
-            {order[0]?.ParentOrKid=='Kid'&&!order[0].ProduccionGO && <div><b>Planned Quantity:</b>  {formatNumber(Number(order[0]?.PlannedQty))} Mixes</div>}
+            {order[0]?.ParentOrKid==='Kid'&&order[0].ProduccionGO && <div><b>{t('productionOrder.plannedQuantity')}:</b>  {formatNumber(Number(order[0]?.PlannedQty))} EA ({Math.ceil(formatNumber(Number(order[0]?.PlannedQty))/order[0].UndXPallet)} Pallets)</div>}
+            {order[0]?.ParentOrKid==='Parent'&&!order[0].ProduccionGO && <div><b>{t('productionOrder.plannedQuantity')}:</b>  {formatNumber(Number(order[0]?.PlannedQty))} EA ({Math.ceil(formatNumber(Number(order[0]?.PlannedQty))/order[0].UndXPallet)} Pallets)</div>}
+            {order[0]?.ParentOrKid=='Kid'&&!order[0].ProduccionGO && <div><b>{t('productionOrder.plannedQuantity')}:</b>  {formatNumber(Number(order[0]?.PlannedQty))} Mixes</div>}
             <div><b>Warehouse:</b> {order[0]?.Warehouse}</div>
             <div><b>Best Buy Date:</b> {formatDate(addDaysToDate(new Date(), order[0]?.BestBeforeDays))}</div>
           </div>
           <div className="p-col-12 p-md-6">
           <div><b>Status:</b> {order[0]?.Status}</div>
            
-            <div><b>Delivery Date:</b> {new Date(order[0]?.DeliveryDate).toLocaleDateString('en-US', options)}</div>
-            {!allItems && <div><b>Start Date:</b> {order[0]?.StartDate ? new Date(order[0]?.StartDate).toLocaleDateString('en-US', options) : ''}</div>}
-            {!allItems && <div><b>Finish Date:</b> {order[0]?.DueDate ? new Date(order[0]?.DueDate).toLocaleDateString('en-US', options) : ''}</div>}
+            <div><b>{t('productionPage.deliveryDate')}:</b> {new Date(order[0]?.DeliveryDate).toLocaleDateString('en-US', options)}</div>
+            {!allItems && <div><b>{t('productionOrder.startDate')}:</b> {order[0]?.StartDate ? new Date(order[0]?.StartDate).toLocaleDateString('en-US', options) : ''}</div>}
+            {!allItems && <div><b>{t('productionOrder.finishDate')}:</b> {order[0]?.DueDate ? new Date(order[0]?.DueDate).toLocaleDateString('en-US', options) : ''}</div>}
             <div><b>No. (PO):</b> {order[0]?.DocNum}</div>
             {allItems&&<div style={{'color':'#007ad9' , 'padding-top':'1rem', 'fontSize':'24px'}}><b>{order[0]?.TypeDetail === 'Pallets' ? "#Pallets "+ line +' '+ shift +':': "#Mixes "+line +' '+ shift +':'}</b>  { (order[0]?.TypeDetail === 'Mixes' ?  (mixesByShift === null ?0 :mixesByShift) : palletByShift)}</div>}
 
@@ -924,8 +926,8 @@ else
                 <>
                   {!order[0]?.StartTime && <Button label="Start" icon="pi pi-play" className="p-button-success p-mr-2" onClick={handleStartProduction} disabled={!!startTime || order[0]?.StartTime} rounded />}
                   <Button label="Close PO" icon="pi-stop-circle" className="p-button-danger" onClick={handleEndProductionClick} disabled={!order[0]?.StartTime || order[0].CloseDate} rounded />
-                  {order[0]?.IsPaused === 'N' && order[0]?.StartTime && <Button label="Pause" icon="pi pi-pause" className="p-button font-bold" onClick={handlePauseProduction} disabled={order[0]?.IsPaused === 'Y' || order[0].CloseDate} rounded />}
-                  {order[0]?.IsPaused === 'Y' && <Button label="Resume" icon="pi-reply" onClick={handleResumeProduction} disabled={order[0]?.IsPaused === 'N' || order[0].CloseDate} rounded style={{ backgroundColor: '#2196F3', borderColor: '#2196F3', color: '#fff' }} />}
+                  {order[0]?.IsPaused === 'N' && order[0]?.StartTime && <Button label={t('productionPage.pause')} icon="pi pi-pause" className="p-button font-bold" onClick={handlePauseProduction} disabled={order[0]?.IsPaused === 'Y' || order[0].CloseDate} rounded />}
+                  {order[0]?.IsPaused === 'Y' && <Button label={t('productionPage.resume')} icon="pi-reply" onClick={handleResumeProduction} disabled={order[0]?.IsPaused === 'N' || order[0].CloseDate} rounded style={{ backgroundColor: '#2196F3', borderColor: '#2196F3', color: '#fff' }} />}
                 </>
               )}
             </div>
@@ -939,7 +941,7 @@ else
               <div className='production-buttons'>
                 {/* {order[0].ProduccionGO !== 'Y' && <Button label="Product Reception" className="p-button-danger" onClick={showBatchDialog} disabled={order[0].CloseDate}  rounded/>} */}
                 <Button
-                  label={order[0]?.TypeDetail === 'Pallets' ? "Add Pallet" : "Add Mix"}
+                  label={order[0]?.TypeDetail === 'Pallets' ? t('productionPage.addPallet') : t('productionPage.addMix')}
                   className="p-order[0].button-success p-mr-2"
                   onClick={() => handleButtonClick(order)}
                   disabled={

--- a/pages/tortillas/index.jsx
+++ b/pages/tortillas/index.jsx
@@ -3,15 +3,15 @@
 
 import React from 'react';
 import ProductionOrders from '../../components/ProductionOrderList/ProductionOrderList';
+import { useTranslation } from '../../utilities/i18n';
 
 const TortillaProductionOrders = () => {
- 
+  const { t } = useTranslation();
+
   return (
-    <div >
-   
-      <ProductionOrders type='Tortillas'/>
+    <div>
+      <ProductionOrders type={t('tortillas')} />
     </div>
-   
   );
 };
 

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -7,6 +7,15 @@
     "first": "First Dataset",
     "second": "Second Dataset"
   },
+  "warning": "Warning",
+  "success": "Success",
+  "error": "Error",
+  "tortillas": "Tortillas",
+  "warningDialog": {
+    "title": "Warning!",
+    "cancel": "Cancel",
+    "ok": "OK"
+  },
   "months": {
     "january": "January",
     "february": "February",
@@ -88,5 +97,43 @@
     "actions": "Actions",
     "produce": "Produce",
     "issue": "Issue"
+  },
+  "productionPage": {
+    "finalizeConfirmation": "Are you sure you want to finalize the production? Once the Production Order is closed, you will no longer be able to add new mixes or receive finished goods. If you agree, click OK; otherwise, click Cancel",
+    "someComponentsNotIssued": "Some components have not been issued. Please review the components related to seasoning/oil.",
+    "notEnoughDough": "There is not enough dough quantity to continue generating pallets. Please complete mixes.",
+    "productionPaused": "Production paused successfully",
+    "productionPauseFailed": "Failed to pause production",
+    "productionResumed": "Production resumed successfully",
+    "productionResumeFailed": "Failed to resume production",
+    "productionStarted": "Production started successfully",
+    "productionStartFailed": "Failed to start production",
+    "allOrdersClosed": "All production orders closed successfully",
+    "closeOrdersFailed": "Failed to close production orders",
+    "review": "Review",
+    "pause": "Pause",
+    "resume": "Resume",
+    "addPallet": "Add Pallet",
+    "addMix": "Add Mix",
+    "deliveryDate": "Delivery Date"
+  },
+  "productionList": {
+    "orders": "Production Orders",
+    "selectStatus": "Select a Status",
+    "searchCustomerPO": "Search by Customer PO",
+    "customerPO": "Customer PO",
+    "status": "Status",
+    "sku": "SKU",
+    "productDescription": "Product Description",
+    "originPOs": "Origin POs",
+    "mixes": "Mixes",
+    "pallets": "Pallets",
+    "startedDate": "Started Date",
+    "finishDate": "Finish Date",
+    "deliveryDate": "Delivery Date",
+    "statusAll": "All",
+    "statusReleased": "Released",
+    "statusOpen": "Open",
+    "statusClose": "Close"
   }
 }

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -7,6 +7,15 @@
     "first": "Primer Conjunto",
     "second": "Segundo Conjunto"
   },
+  "warning": "Advertencia",
+  "success": "Éxito",
+  "error": "Error",
+  "tortillas": "Tortillas",
+  "warningDialog": {
+    "title": "¡Advertencia!",
+    "cancel": "Cancelar",
+    "ok": "OK"
+  },
   "months": {
     "january": "Enero",
     "february": "Febrero",
@@ -88,5 +97,43 @@
     "actions": "Acciones",
     "produce": "Producir",
     "issue": "Emitir"
+  },
+  "productionPage": {
+    "finalizeConfirmation": "¿Estás seguro de que deseas finalizar la producción? Una vez que la Orden de Producción esté cerrada, ya no podrás agregar nuevas mezclas ni recibir productos terminados. Si estás de acuerdo, haz clic en OK; de lo contrario, haz clic en Cancelar",
+    "someComponentsNotIssued": "Algunos componentes no se han emitido. Por favor revisa los componentes relacionados con condimentos/aceite.",
+    "notEnoughDough": "No hay suficiente masa para continuar generando pallets. Por favor completa las mezclas.",
+    "productionPaused": "Producción pausada correctamente",
+    "productionPauseFailed": "Error al pausar la producción",
+    "productionResumed": "Producción reanudada correctamente",
+    "productionResumeFailed": "Error al reanudar la producción",
+    "productionStarted": "Producción iniciada correctamente",
+    "productionStartFailed": "Error al iniciar la producción",
+    "allOrdersClosed": "Todas las órdenes de producción cerradas correctamente",
+    "closeOrdersFailed": "Error al cerrar las órdenes de producción",
+    "review": "Revisar",
+    "pause": "Pausar",
+    "resume": "Reanudar",
+    "addPallet": "Agregar Pallet",
+    "addMix": "Agregar Mezcla",
+    "deliveryDate": "Fecha de entrega"
+  },
+  "productionList": {
+    "orders": "Órdenes de Producción",
+    "selectStatus": "Seleccionar un Estado",
+    "searchCustomerPO": "Buscar por PO del Cliente",
+    "customerPO": "PO del Cliente",
+    "status": "Estado",
+    "sku": "SKU",
+    "productDescription": "Descripción del Producto",
+    "originPOs": "POs de Origen",
+    "mixes": "Mezclas",
+    "pallets": "Pallets",
+    "startedDate": "Fecha de Inicio",
+    "finishDate": "Fecha de Finalización",
+    "deliveryDate": "Fecha de Entrega",
+    "statusAll": "Todos",
+    "statusReleased": "Liberado",
+    "statusOpen": "Abierto",
+    "statusClose": "Cerrado"
   }
 }


### PR DESCRIPTION
## Summary
- replace static strings with `t()` in production pages and warning dialog
- add locale keys for dialogs, tables and production helpers
- translate ProductionOrderList interface

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68b4ac5b8e988325a21792bd113e6550