### PR TITLE
feat: expand spanish translations

### DIFF
--- a/components/ProductionOrderListChips/ProductionOrderListChips.jsx
+++ b/components/ProductionOrderListChips/ProductionOrderListChips.jsx
@@ -15,6 +15,7 @@ import 'primereact/resources/primereact.min.css';
 import 'primeflex/primeflex.css';
 import { Card } from 'primereact/card';
 import {formatDate} from '../../utilities/formatDate'
+import { useTranslation } from '../../utilities/i18n';
 
 const ProductionOrders = ({ type }) => {
   const [pOrders, setPOrders] = useState([]);
@@ -28,12 +29,13 @@ const ProductionOrders = ({ type }) => {
   const [group, setGroup] = useState(null)
   const [customerPOSearch, setCustomerPOSearch] = useState('');
   const toast = useRef(null);
+  const { t } = useTranslation();
 
   const statusOptions = [
-    { label: 'All', value: 'All' },
-    { label: 'Released', value: 'Released' },
-    { label: 'Open', value: 'Open' },
-    { label: 'Close', value: 'Close' },
+    { label: t('productionList.statusAll'), value: 'All' },
+    { label: t('productionList.statusReleased'), value: 'Released' },
+    { label: t('productionList.statusOpen'), value: 'Open' },
+    { label: t('productionList.statusClose'), value: 'Close' },
   ];
 
   useEffect(() => {
@@ -351,42 +353,42 @@ const ProductionOrders = ({ type }) => {
         <DataTable value={details} scrollable scrollHeight="200px" style={styles.expansionTable}>
           <Column
             field="CustomerPO"
-            header="Customer PO"
+            header={t('productionList.customerPO')}
             headerStyle={styles.expansionTableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '30rem' }}
           />
           {/* <Column
             field="Status"
-            header="Status"
+            header={t('productionList.status')}
             headerStyle={styles.expansionTableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '15rem' }}
           /> */}
           <Column
             field="ItemCode"
-            header="SKU"
+            header={t('productionList.sku')}
             headerStyle={styles.expansionTableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '20rem' }}
           />
           <Column
             field="ProdName"
-            header="Product Description"
+            header={t('productionList.productDescription')}
             headerStyle={styles.expansionTableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '60rem' }}
           />
           <Column
             field="DocNum"
-            header="Origin POs"
+            header={t('productionList.originPOs')}
             headerStyle={styles.expansionTableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '15rem' }}
           />
           <Column
             field="PlannedQty"
-            header="Planned Quantity"
+            header={t('productionOrder.plannedQuantity')}
             body={(rowData) => parseFloat(rowData.PlannedQty).toFixed(0)}
             headerStyle={styles.expansionTableHeader}
             bodyStyle={styles.tableBody}
@@ -394,35 +396,35 @@ const ProductionOrders = ({ type }) => {
           />
           {/* <Column
             body={infoMixes}
-            header="Mixes"
+            header={t('productionList.mixes')}
             headerStyle={styles.expansionTableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '10rem' }}
           /> */}
           <Column
             body={infoPallets}
-            header="Pallets"
+            header={t('productionList.pallets')}
             headerStyle={styles.expansionTableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '10rem' }}
           />
           {/* <Column
             body={dateTemplate}
-            header="Started Date"
+            header={t('productionList.startedDate')}
             headerStyle={styles.expansionTableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '20rem' }}
           />
           <Column
             body={dateTemplateFinish}
-            header="Finish Date"
+            header={t('productionList.finishDate')}
             headerStyle={styles.expansionTableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '20rem' }}
           /> */}
           <Column
             body={dateTemplateDelivery}
-            header="Delivery Date"
+            header={t('productionList.deliveryDate')}
             headerStyle={styles.expansionTableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '20rem' }}
@@ -437,33 +439,33 @@ const ProductionOrders = ({ type }) => {
       <Card>
         <Toast ref={toast} />
         <div style={styles.header}>
-          <h1 style={styles.title}>{type} Production Orders</h1>
+          <h1 style={styles.title}>{t('menu.chips')} {t('productionList.orders')}</h1>
           <div style={styles.controls}>
             <Dropdown
               value={statusFilter}
               options={statusOptions}
               onChange={onStatusChange}
-              placeholder="Select a Status"
+              placeholder={t('productionList.selectStatus')}
               style={styles.dropdown}
             />
             <InputText
               type="text"
               value={customerPOSearch}
               onChange={onCustomerPOSearchChange}
-              placeholder="Search by Customer PO"
+              placeholder={t('productionList.searchCustomerPO')}
               style={styles.searchBox}
             />
             {group === 'Y' &&
-            < >
+            <>
             <Button
-              label="Group"
+              label={t('productionList.group')}
               onClick={handleProduceClick}
               disabled={selectedOrders.length === 0 || selectedOrders.some(order => order.Group !== null)}
               style={styles.groupButton}
             />
             <span>   </span>
             <Button
-              label="Ungroup"
+              label={t('productionList.ungroup')}
               onClick={handleUngroupClick}
               disabled={selectedOrders.length === 0 || selectedOrders.every(order => order.Group === null)} // Deshabilitar si no hay órdenes agrupadas
               style={styles.ungroupButton}
@@ -503,42 +505,42 @@ const ProductionOrders = ({ type }) => {
 
           <Column
             body={linkTemplate}
-            header="Customer PO"
+            header={t('productionList.customerPO')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '30rem' }}
           />
           <Column
             field="Status"
-            header="Status"
+            header={t('productionList.status')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '15rem' }}
           />
           <Column
             field="ItemCode"
-            header="SKU"
+            header={t('productionList.sku')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '20rem' }}
           />
           <Column
             field="ProdName"
-            header="Product Description"
+            header={t('productionList.productDescription')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '60rem' }}
           />
           <Column
             field="DocNum"
-            header="Origin POs"
+            header={t('productionList.originPOs')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '15rem' }}
           />
           <Column
             field="PlannedQty"
-            header="Planned Quantity"
+            header={t('productionOrder.plannedQuantity')}
             body={(rowData) => `${parseFloat(rowData.PlannedQty).toFixed(0)} ${rowData.SalUnitMsr}`}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody1}
@@ -546,35 +548,35 @@ const ProductionOrders = ({ type }) => {
           />
           <Column
             body={infoMixes}
-            header="Mixes"
+            header={t('productionList.mixes')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '10rem' }}
           />
           {/* <Column
             body={infoPallets}
-            header="Pallets"
+            header={t('productionList.pallets')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '10rem' }}
           /> */}
           <Column
             body={dateTemplate}
-            header="Started Date"
+            header={t('productionList.startedDate')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '20rem' }}
           />
           <Column
             body={dateTemplateFinish}
-            header="Finish Date"
+            header={t('productionList.finishDate')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '20rem' }}
           />
           <Column
             body={dateTemplateDelivery}
-            header="Delivery Date"
+            header={t('productionList.deliveryDate')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '20rem' }}

--- a/components/ProductionOrderListVariety/ProductionOrderListVariety.jsx
+++ b/components/ProductionOrderListVariety/ProductionOrderListVariety.jsx
@@ -9,6 +9,7 @@ import { Dropdown } from 'primereact/dropdown';
 import { InputText } from 'primereact/inputtext';
 import { Card } from 'primereact/card';
 import { formatDate } from '../../utilities/formatDate'
+import { useTranslation } from '../../utilities/i18n';
 
 const ProductionOrders = ({ type }) => {
   const [pOrders, setPOrders] = useState([]);
@@ -16,12 +17,13 @@ const ProductionOrders = ({ type }) => {
   const [statusFilter, setStatusFilter] = useState('All');
   const [searchTerm, setSearchTerm] = useState('');
   const [customerPOSearch, setCustomerPOSearch] = useState('');
+  const { t } = useTranslation();
 
   const statusOptions = [
-    { label: 'All', value: 'All' },
-    { label: 'Released', value: 'Released' },
-    { label: 'Open', value: 'Open' },
-    { label: 'Close', value: 'Close' },
+    { label: t('productionList.statusAll'), value: 'All' },
+    { label: t('productionList.statusReleased'), value: 'Released' },
+    { label: t('productionList.statusOpen'), value: 'Open' },
+    { label: t('productionList.statusClose'), value: 'Close' },
   ];
 
   useEffect(() => {
@@ -119,19 +121,19 @@ const ProductionOrders = ({ type }) => {
     <>
       <Card>
         <div style={styles.header}>
-          <h1 style={styles.title}>{type} Production Orders</h1>
+          <h1 style={styles.title}>{t('menu.varietyPack')} {t('productionList.orders')}</h1>
           <div style={styles.filters}>
             <Dropdown
               value={statusFilter}
               options={statusOptions}
               onChange={onStatusChange}
-              placeholder="Select a Status"
+              placeholder={t('productionList.selectStatus')}
               style={styles.dropdown}
             />
             <InputText
               value={customerPOSearch}
               onChange={onCustomerPOSearchChange}
-              placeholder="Search by Customer PO"
+              placeholder={t('productionList.searchCustomerPO')}
               style={styles.searchInput}
             />
           </div>
@@ -145,42 +147,42 @@ const ProductionOrders = ({ type }) => {
         >
           <Column
             body={linkTemplate}
-            header="Customer PO"
+            header={t('productionList.customerPO')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '30rem' }}
           />
           <Column
             field="Status"
-            header="Status"
+            header={t('productionList.status')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '15rem' }}
           />
           <Column
             field="ItemCode"
-            header="SKU"
+            header={t('productionList.sku')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '20rem' }}
           />
           <Column
             field="ProdName"
-            header="Product Description"
+            header={t('productionList.productDescription')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '60rem' }}
           />
           <Column
             field="DocNum"
-            header="Origin POs"
+            header={t('productionList.originPOs')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '15rem' }}
           />
           <Column
             field="PlannedQty"
-            header="Planned Quantity"
+            header={t('productionOrder.plannedQuantity')}
             body={(rowData) => `${parseFloat(rowData.PlannedQty).toFixed(0)} ${rowData.SalUnitMsr}`}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody1}
@@ -188,35 +190,35 @@ const ProductionOrders = ({ type }) => {
           />
           {/* <Column
             body={infoMixes}
-            header="Mixes"
+            header={t('productionList.mixes')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '10rem' }}
           /> */}
           <Column
             body={infoPallets}
-            header="Pallets"
+            header={t('productionList.pallets')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '10rem' }}
           />
           <Column
             body={dateTemplate}
-            header="Started Date"
+            header={t('productionList.startedDate')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '20rem' }}
           />
           <Column
             body={dateTemplateFinish}
-            header="Finish Date"
+            header={t('productionList.finishDate')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '20rem' }}
           />
           <Column
             body={dateTemplateDelivery}
-            header="Delivery Date"
+            header={t('productionList.deliveryDate')}
             headerStyle={styles.tableHeader}
             bodyStyle={styles.tableBody}
             style={{ width: '20rem' }}

--- a/layout/AppMenu.js
+++ b/layout/AppMenu.js
@@ -5,10 +5,12 @@ import AppMenuitem from './AppMenuitem';
 import { LayoutContext } from './context/layoutcontext';
 import { MenuProvider } from './context/menucontext';
 import { useRouter } from 'next/navigation';
+import { useTranslation } from '../utilities/i18n';
 
 const AppMenu = () => {
     const { layoutConfig } = useContext(LayoutContext);
     const router = useRouter();
+    const { t } = useTranslation();
     const [path, setPath] = useState('');
 
     useEffect(() => {
@@ -23,65 +25,64 @@ const AppMenu = () => {
     const productionItems = [];
 
     if (path === 'Tortilla' || path === 'All') {
-        productionItems.push({ 
-            label: 'Tortillas', 
-            icon: 'pi pi-fw pi-circle icon-white', 
-            command: () => router.push('/tortillas') 
+        productionItems.push({
+            label: t('tortillas'),
+            icon: 'pi pi-fw pi-circle icon-white',
+            command: () => router.push('/tortillas')
         });
     }
 
     if (path === 'Chips' || path === 'All') {
-        productionItems.push({ 
-            label: 'Chips', 
-            icon: 'pi pi-caret-right icon-white'
-,
-            command: () => router.push('/chips') 
+        productionItems.push({
+            label: t('menu.chips'),
+            icon: 'pi pi-caret-right icon-white',
+            command: () => router.push('/chips')
         });
     }
 
             if (path === 'Chips' || path === 'All') {
-                productionItems.push({ 
-                    label: 'Variety Pack', 
-                    icon: 'pi pi-fw pi-box icon-white', 
-                    command: () => router.push('/variety-pack') 
+                productionItems.push({
+                    label: t('menu.varietyPack'),
+                    icon: 'pi pi-fw pi-box icon-white',
+                    command: () => router.push('/variety-pack')
                 });
             }
 
             if (path === 'Chips' || path === 'Tortilla'  || path === 'All') {
-                productionItems.push({ 
-                    label: 'Waste', 
-                    icon: 'pi pi-fw pi-trash icon-white', 
-                    command: () => router.push('/waste') 
+                productionItems.push({
+                    label: t('menu.waste'),
+                    icon: 'pi pi-fw pi-trash icon-white',
+                    command: () => router.push('/waste')
                 });
             }
 
 
             if ( path === 'All') {
-                productionItems.push({ 
-                    label: 'DownTime', 
-                    icon: 'pi pi-clock pi-fw icon-white', 
-                    command: () => router.push('/downtime') 
+                productionItems.push({
+                    label: t('menu.downTime'),
+                    icon: 'pi pi-clock pi-fw icon-white',
+                    command: () => router.push('/downtime')
                 });
             }
 
             if (path === 'Tortilla' || path === 'All'){
-                productionItems.push({ 
-                    label: 'Report Tortillas', 
-                    icon: 'pi pi-file pi-fw icon-white', 
-                    command: () => router.push('/report') 
+                productionItems.push({
+                    label: t('menu.reportTortillas'),
+                    icon: 'pi pi-file pi-fw icon-white',
+                    command: () => router.push('/report')
                 });
             }
     const model = [
 
         {
-            label: 'Production',
+            label: t('menu.production'),
             items: productionItems.length ? productionItems : []
         },
         {
-            label: 'Session',
-            items: [{ 
-                label: 'Log out', 
-                icon: 'pi pi-fw pi-sign-out icon-white', 
+            label: t('menu.session'),
+            items: [{
+                label: t('logout'),
+                icon: 'pi pi-fw pi-sign-out icon-white',
                 command: () => {
                     localStorage.clear();
                     sessionStorage.clear();

--- a/pages/chips/index.jsx
+++ b/pages/chips/index.jsx
@@ -3,16 +3,16 @@
 
 import React from 'react';
 import ProductionOrders from '../../components/ProductionOrderListChips/ProductionOrderListChips';
-
+import { useTranslation } from '../../utilities/i18n';
 
 const ChipsProductionOrders = () => {
- 
+  const { t } = useTranslation();
+
   return (
-   
         <div>
-      <ProductionOrders type='Chips'/>
+      <ProductionOrders type={t('menu.chips')}/>
       </div>
-   
+
   );
 };
 

--- a/pages/chips/prueba/index.jsx
+++ b/pages/chips/prueba/index.jsx
@@ -3,16 +3,16 @@
 
 import React from 'react';
 import ProductionOrders from '../../../components/ProductionOrderListChips/ProductionOrderListChips';
-
+import { useTranslation } from '../../../utilities/i18n';
 
 const ChipsProductionOrders = () => {
- 
+  const { t } = useTranslation();
+
   return (
-   
         <div>
-      <ProductionOrders type='Chips'/>
+      <ProductionOrders type={t('menu.chips')}/>
       </div>
-   
+
   );
 };
 

--- a/pages/production/[id].jsx
+++ b/pages/production/[id].jsx
@@ -865,7 +865,7 @@ else
   return (
     <div>
       <Toast ref={toast} position="top-right" style={{ marginTop: '60px', zIndex: 9999 }} />
-      <Card title={<span><BackButton /> Production Order </span>} className="p-card">
+      <Card title={<span><BackButton /> {t('productionOrder.title')} </span>} className="p-card">
       {loadingStart && (
                     <div className="p-d-flex p-jc-center p-ai-center" style={{ marginTop: '1rem' }}>
                         <ProgressSpinner style={{ width: '50px', height: '50px' }} />
@@ -983,21 +983,21 @@ else
           </div>)}
         </div>
       </Card>
-      <Card title="Components" className="p-card p-mt-3">
+      <Card title={t('productionOrder.components')} className="p-card p-mt-3">
         <div className="p-datatable-wrapper">
           <DataTable value={order} paginator rows={10} scrollable scrollHeight="400px">
-            {/* <Column field="Type" header="Type" /> */}
-            <Column field="ItemCode2" header="Product" />
-            <Column field="ItemName" header="Description" />
+            {/* <Column field="Type" header={t('productionOrder.type')} /> */}
+            <Column field="ItemCode2" header={t('productionOrder.product')} />
+            <Column field="ItemName" header={t('productionOrder.description')} />
             {/* {allItems &&<Column field="Und" header="Und" />} */}
-            <Column field="BaseQtyLine" header="Base Quantity" body={(rowData) => formatNumber(parseFloat(rowData.BaseQtyLine))} />
-            <Column field="PlannedQtyLine" header="Planned" body={(rowData) => formatNumber(parseFloat(rowData.PlannedQtyLine))} />
+            <Column field="BaseQtyLine" header={t('productionOrder.baseQuantity')} body={(rowData) => formatNumber(parseFloat(rowData.BaseQtyLine))} />
+            <Column field="PlannedQtyLine" header={t('productionOrder.planned')} body={(rowData) => formatNumber(parseFloat(rowData.PlannedQtyLine))} />
 
             {/* <Column field="Available" header="Available" body={(rowData) => parseFloat(rowData.Available).toFixed(3)} /> */}
-            {!allItems && <Column field="QtyChildrenCmpl" header="Produced" body={(rowData) => formatNumber(parseFloat(rowData.QtyChildrenCmpl || 0))} />}
-            <Column field="IssuedQty" header="Issued" body={(rowData) => formatNumber(parseFloat(rowData.IssuedQty))} />
-            {!allItems && <Column field="POChildrenDocNum" header="Child PO" />}
-            {!allItems && <Column body={actionTemplate} header="Actions" />}
+            {!allItems && <Column field="QtyChildrenCmpl" header={t('productionOrder.produced')} body={(rowData) => formatNumber(parseFloat(rowData.QtyChildrenCmpl || 0))} />}
+            <Column field="IssuedQty" header={t('productionOrder.issued')} body={(rowData) => formatNumber(parseFloat(rowData.IssuedQty))} />
+            {!allItems && <Column field="POChildrenDocNum" header={t('productionOrder.childPO')} />}
+            {!allItems && <Column body={actionTemplate} header={t('productionOrder.actions')} />}
 
 
           </DataTable>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -11,6 +11,15 @@
   "success": "Success",
   "error": "Error",
   "tortillas": "Tortillas",
+  "menu": {
+    "chips": "Chips",
+    "varietyPack": "Variety Pack",
+    "waste": "Waste",
+    "downTime": "DownTime",
+    "reportTortillas": "Report Tortillas",
+    "production": "Production",
+    "session": "Session"
+  },
   "warningDialog": {
     "title": "Warning!",
     "cancel": "Cancel",
@@ -96,7 +105,8 @@
     "childPO": "Child PO",
     "actions": "Actions",
     "produce": "Produce",
-    "issue": "Issue"
+    "issue": "Issue",
+    "produced": "Produced"
   },
   "productionPage": {
     "finalizeConfirmation": "Are you sure you want to finalize the production? Once the Production Order is closed, you will no longer be able to add new mixes or receive finished goods. If you agree, click OK; otherwise, click Cancel",
@@ -134,6 +144,8 @@
     "statusAll": "All",
     "statusReleased": "Released",
     "statusOpen": "Open",
-    "statusClose": "Close"
+    "statusClose": "Close",
+    "group": "Group",
+    "ungroup": "Ungroup"
   }
 }

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -11,6 +11,15 @@
   "success": "Éxito",
   "error": "Error",
   "tortillas": "Tortillas",
+  "menu": {
+    "chips": "Chips",
+    "varietyPack": "Variety Pack",
+    "waste": "Desperdicio",
+    "downTime": "Tiempo Muerto",
+    "reportTortillas": "Reporte de Tortillas",
+    "production": "Producción",
+    "session": "Sesión"
+  },
   "warningDialog": {
     "title": "¡Advertencia!",
     "cancel": "Cancelar",
@@ -96,7 +105,8 @@
     "childPO": "Orden Hija",
     "actions": "Acciones",
     "produce": "Producir",
-    "issue": "Emitir"
+    "issue": "Emitir",
+    "produced": "Producido"
   },
   "productionPage": {
     "finalizeConfirmation": "¿Estás seguro de que deseas finalizar la producción? Una vez que la Orden de Producción esté cerrada, ya no podrás agregar nuevas mezclas ni recibir productos terminados. Si estás de acuerdo, haz clic en OK; de lo contrario, haz clic en Cancelar",
@@ -134,6 +144,8 @@
     "statusAll": "Todos",
     "statusReleased": "Liberado",
     "statusOpen": "Abierto",
-    "statusClose": "Cerrado"
+    "statusClose": "Cerrado",
+    "group": "Agrupar",
+    "ungroup": "Desagrupar"
   }
 }


### PR DESCRIPTION
## Summary
- translate sidebar navigation and production pages to use i18n
- localize production order tables and column headers
- add menu and production keys to translation files

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b4abe82eac8325a4f343046e7d239e