### PR TITLE
feat: localize production variety components

### DIFF
--- a/components/IssueProductionVariety/IssueProductionVariety.jsx
+++ b/components/IssueProductionVariety/IssueProductionVariety.jsx
@@ -15,6 +15,7 @@ import { RadioButton } from 'primereact/radiobutton';
 import { Card } from 'primereact/card';
 import formatNumber from '../../utilities/formatNumber';
 import { formatDate } from '../../utilities/formatDate';
+import { useTranslation } from '../../utilities/i18n';
 const IssueProduction = ({ visible, onHide, data, pallet, onSave, parentEntry, chips, chips1, ParentOrKid, Variety }) => {
     const BASE_URL = process.env.NEXT_PUBLIC_API_UR;
     const [formData, setFormData] = useState({ wetTime: '', dryTime: '', rows: [] });
@@ -25,6 +26,7 @@ const IssueProduction = ({ visible, onHide, data, pallet, onSave, parentEntry, c
 
     const [loading, setLoading] = useState(false);
     const toast = useRef(null);
+    const { t } = useTranslation();
     const [shift, setShift] = useState(localStorage.getItem("shift"));
     const [line, setLine] = useState(localStorage.getItem("line"));
     const [docEntries, setDocEntries] = useState(null);
@@ -812,8 +814,8 @@ const IssueProduction = ({ visible, onHide, data, pallet, onSave, parentEntry, c
             if (item.batch === 'Y' && item.lotNumbers.some((lot) => parseFloat(lot.quantity) === 0 || !lot.quantity)) {
                 toast.current.show({
                     severity: 'warn',
-                    summary: 'Warning',
-                    detail: 'Lot quantities cannot be zero.',
+                    summary: t('warning'),
+                    detail: t('issueProductionVariety.lotQtyZero'),
                 });
                 valid = false;
             }
@@ -821,8 +823,8 @@ const IssueProduction = ({ visible, onHide, data, pallet, onSave, parentEntry, c
             if (parseFloat(item.real) == 0 || !item.real) {
                 toast.current.show({
                     severity: 'warn',
-                    summary: 'Warning',
-                    detail: 'The quantities cannot be zero.',
+                    summary: t('warning'),
+                    detail: t('issueProductionVariety.qtyZero'),
                 });
                 valid = false;
             }
@@ -830,8 +832,8 @@ const IssueProduction = ({ visible, onHide, data, pallet, onSave, parentEntry, c
             if (parseFloat(item.real) > totalLotQuantity && totalLotQuantity != 0 && item.batch === 'Y') {
                 toast.current.show({
                     severity: 'warn',
-                    summary: 'Warning',
-                    detail: 'The quantity cannot exceed the total available in the selected lots.',
+                    summary: t('warning'),
+                    detail: t('issueProductionVariety.exceedAvailable'),
                 });
                 valid = false;
             }
@@ -839,8 +841,8 @@ const IssueProduction = ({ visible, onHide, data, pallet, onSave, parentEntry, c
             if (item.batch === 'Y' && item.lotNumbers.some((lot) => !lot.lotNumber)) {
                 toast.current.show({
                     severity: 'warn',
-                    summary: 'Warning',
-                    detail: 'All batch items must have a selected lot.',
+                    summary: t('warning'),
+                    detail: t('issueProductionVariety.lotRequired'),
                 });
                 valid = false;
             }
@@ -943,7 +945,7 @@ const IssueProduction = ({ visible, onHide, data, pallet, onSave, parentEntry, c
         console.log(pallet)
         if (!validateQuantities()) return;
         if ((!formData.wetTime || !formData.dryTime) && !data[0]?.ProduccionGO && ParentOrKid === 'Kid') {
-            toast.current.show({ severity: 'warn', summary: 'Warning', detail: 'Wet Mix Time and Dry Mix Time are required.' });
+            toast.current.show({ severity: 'warn', summary: t('warning'), detail: t('issueProductionVariety.mixTimesRequired') });
             return;
         }
 
@@ -1042,7 +1044,7 @@ const IssueProduction = ({ visible, onHide, data, pallet, onSave, parentEntry, c
                     .then(result => {
 
                         if (result.Result === 'SUCCESS') {
-                            toast.current.show({ severity: 'success', summary: 'Success', detail: result.Message });
+                            toast.current.show({ severity: 'success', summary: t('success'), detail: result.Message });
                             addOrderToSession(parentEntry);
 
                             console.log(data[0]?.ProduccionGO)
@@ -1065,12 +1067,12 @@ const IssueProduction = ({ visible, onHide, data, pallet, onSave, parentEntry, c
 
                             }
                         } else {
-                            toast.current.show({ severity: 'error', summary: 'Error', detail: result.Message });
+                            toast.current.show({ severity: 'error', summary: t('error'), detail: result.Message });
                         }
                     })
                     .catch(error => {
                         console.error('Error:', error);
-                        toast.current.show({ severity: 'error', summary: 'Error', detail: 'An unexpected error occurred' });
+                        toast.current.show({ severity: 'error', summary: t('error'), detail: t('productionInfo.unknownError') });
                     });
             });
 
@@ -1125,7 +1127,7 @@ const IssueProduction = ({ visible, onHide, data, pallet, onSave, parentEntry, c
                 const result = await response.json();
 
                 if (response.ok) {
-                    toast.current.show({ severity: 'success', summary: 'Success', detail: result.Message });
+                    toast.current.show({ severity: 'success', summary: t('success'), detail: result.Message });
                     addOrderToSession(parentEntry);
                     console.log(data[0]?.Type)
                     if (!data[0]?.ProduccionGO && data[0]?.ParentOrKid === 'Kid') {
@@ -1142,19 +1144,19 @@ const IssueProduction = ({ visible, onHide, data, pallet, onSave, parentEntry, c
                         const receiptResponse = await receiptResult.json();
 
                         if (receiptResult.ok) {
-                            toast.current.show({ severity: 'success', summary: 'Success', detail: receiptResponse.Message });
+                            toast.current.show({ severity: 'success', summary: t('success'), detail: receiptResponse.Message });
                         } else {
-                            toast.current.show({ severity: 'error', summary: 'Error', detail: receiptResponse.Message });
+                            toast.current.show({ severity: 'error', summary: t('error'), detail: receiptResponse.Message });
                         }
                     }
                     onHide(false);
                     onSave(true);
                 } else {
-                    toast.current.show({ severity: 'error', summary: 'Error', detail: result.Message });
+                    toast.current.show({ severity: 'error', summary: t('error'), detail: result.Message });
                 }
             } catch (error) {
                 console.error('Error:', error);
-                toast.current.show({ severity: 'error', summary: 'Error', detail: 'An unexpected error occurred' });
+                toast.current.show({ severity: 'error', summary: t('error'), detail: t('productionInfo.unknownError') });
             }
         }
 
@@ -1236,7 +1238,7 @@ const IssueProduction = ({ visible, onHide, data, pallet, onSave, parentEntry, c
 
             if (response.ok) {
                 console.log("aqui")
-                toast.current.show({ severity: 'success', summary: 'Success', detail: result.Message });
+                toast.current.show({ severity: 'success', summary: t('success'), detail: result.Message });
                 addOrderToSession(parentEntry);
 
                 if (!data[0].ProduccionGO) {
@@ -1253,19 +1255,19 @@ const IssueProduction = ({ visible, onHide, data, pallet, onSave, parentEntry, c
                     const receiptResponse = await receiptResult.json();
 
                     if (receiptResult.ok) {
-                        toast.current.show({ severity: 'success', summary: 'Success', detail: receiptResponse.Message });
+                        toast.current.show({ severity: 'success', summary: t('success'), detail: receiptResponse.Message });
                     } else {
-                        toast.current.show({ severity: 'error', summary: 'Error', detail: receiptResponse.Message });
+                        toast.current.show({ severity: 'error', summary: t('error'), detail: receiptResponse.Message });
                     }
                 } else {
                     onHide(true, true);
                 }
             } else {
-                toast.current.show({ severity: 'error', summary: 'Error', detail: result.Message });
+                toast.current.show({ severity: 'error', summary: t('error'), detail: result.Message });
             }
         } catch (error) {
             console.error('Error:', error);
-            toast.current.show({ severity: 'error', summary: 'Error', detail: 'An unexpected error occurred' });
+            toast.current.show({ severity: 'error', summary: t('error'), detail: t('productionInfo.unknownError') });
         } finally {
             setLoading(false);
         }
@@ -1416,16 +1418,16 @@ const IssueProduction = ({ visible, onHide, data, pallet, onSave, parentEntry, c
             <div className="flex flex-wrap gap-3">
                 <div className="flex align-items-center">
                     <div style={{ display: 'flex', alignItems: 'center' }}>
-                        <label>Dry Mix Time:</label>
-                        <InputText value={formData.dryTime} onChange={(e) => onInputChange(e, null, 'dryTime')} type="number" step="0.01" placeholder="time" style={{ width: '7rem', fontSize: '12px' }} required />
-                        <span className="p-inputgroup-addon">{"min"}</span>
+                        <label>{t('issueProductionVariety.dryMixTime')}</label>
+                        <InputText value={formData.dryTime} onChange={(e) => onInputChange(e, null, 'dryTime')} type="number" step="0.01" placeholder={t('issueProductionVariety.timePlaceholder')} style={{ width: '7rem', fontSize: '12px' }} required />
+                        <span className="p-inputgroup-addon">{t('issueProductionVariety.minutes')}</span>
                     </div>
                 </div>
                 <div className="flex align-items-center">
                     <div style={{ display: 'flex', alignItems: 'center' }}>
-                        <label>Wet Mix Time:</label>
-                        <InputText value={formData.wetTime} onChange={(e) => onInputChange(e, null, 'wetTime')} type="number" step="0.01" placeholder="time" style={{ width: '7rem', fontSize: '12px' }} required />
-                        <span className="p-inputgroup-addon">{"min"}</span>
+                        <label>{t('issueProductionVariety.wetMixTime')}</label>
+                        <InputText value={formData.wetTime} onChange={(e) => onInputChange(e, null, 'wetTime')} type="number" step="0.01" placeholder={t('issueProductionVariety.timePlaceholder')} style={{ width: '7rem', fontSize: '12px' }} required />
+                        <span className="p-inputgroup-addon">{t('issueProductionVariety.minutes')}</span>
                     </div>
                 </div>
 
@@ -1438,14 +1440,14 @@ const IssueProduction = ({ visible, onHide, data, pallet, onSave, parentEntry, c
     const footer = (
         <div className="p-d-flex p-jc-end">
 
-            <Button label="Cancel" icon="pi pi-times" className="p-button-danger p-mr-2" onClick={() => onHide(false, false)} />
-            {!pallet && <Button label="Save" icon="pi pi-check"
+            <Button label={t('productionInfo.cancel')} icon="pi pi-times" className="p-button-danger p-mr-2" onClick={() => onHide(false, false)} />
+            {!pallet && <Button label={t('productionInfo.save')} icon="pi pi-check"
                 className="p-button-success"
                 onClick={handleSave}
                 disabled={loading} />}
             {pallet === 'Y' && (
                 <Button
-                    label="Pallet"
+                    label={t('productionList.pallets')}
                     icon="pi pi-check"
                     className="p-button-success"
                     onClick={handleAddPallet}
@@ -1460,15 +1462,15 @@ const IssueProduction = ({ visible, onHide, data, pallet, onSave, parentEntry, c
         <div className="flex flex-wrap gap-3">
             <div className="flex align-items-center">
                 <RadioButton inputId="Full" name="mix" value="Full" onChange={(e) => setMixType(e.value)} checked={mixType === 'Full'} />
-                <label htmlFor="Full" className="ml-2">Full</label>
+                <label htmlFor="Full" className="ml-2">{t('issueProductionVariety.full')}</label>
             </div>
             <div className="flex align-items-center">
                 <RadioButton inputId="Half" name="mix" value="Half" onChange={(e) => setMixType(e.value)} checked={mixType === 'Half'} />
-                <label htmlFor="Half" className="ml-2">Half</label>
+                <label htmlFor="Half" className="ml-2">{t('issueProductionVariety.half')}</label>
             </div>
             {(chips || chips1 === 'CHIPS') && <div className="flex align-items-center">
                 <RadioButton inputId="Double" name="mix" value="Double" onChange={(e) => setMixType(e.value)} checked={mixType === 'Double'} />
-                <label htmlFor="Double" className="ml-2">Double</label>
+                <label htmlFor="Double" className="ml-2">{t('issueProductionVariety.double')}</label>
             </div>}
 
         </div>
@@ -1479,7 +1481,7 @@ const IssueProduction = ({ visible, onHide, data, pallet, onSave, parentEntry, c
             <Toast ref={toast} position="top-right" style={{ marginTop: '60px', zIndex: 9999 }} />
             <Dialog header={
                 <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                    <span>Issue Components</span>
+                    <span>{t('issueProductionVariety.issueComponents')}</span>
                     {loading && <ProgressSpinner style={{ width: '40px', height: '40px' }} />}
                 </div>
             } maximizable visible={visible} onHide={() => onHide(false)} footer={footer} className="good-issue-dialog" style={{ width: '80vw' }} >
@@ -1487,12 +1489,12 @@ const IssueProduction = ({ visible, onHide, data, pallet, onSave, parentEntry, c
                 {!pallet && ParentOrKid == 'Kid' && <div>{mix}</div>}
                 <Card>
                     <DataTable value={formData.rows} >
-                        <Column field="product" header="Product" />
-                        <Column field="description" header="Description" />
-                        <Column field="base" header="Base" />
+                        <Column field="product" header={t('productionOrder.product')} />
+                        <Column field="description" header={t('productionOrder.description')} />
+                        <Column field="base" header={t('productionOrder.baseQuantity')} />
                         <Column
                             field="real"
-                            header="Real"
+                            header={t('issueProductionVariety.real')}
                             body={(rowData, rowIndex) => (
                                 <div style={{ display: 'flex', alignItems: 'center' }}>
                                     <InputText
@@ -1500,14 +1502,14 @@ const IssueProduction = ({ visible, onHide, data, pallet, onSave, parentEntry, c
                                         onChange={(e) => onInputChange(e, rowIndex.rowIndex, 'real')}
                                         type="number"
                                         step="0.01"
-                                        placeholder="Quantity"
+                                        placeholder={t('issueProductionVariety.quantity')}
                                         style={{ width: '7rem', fontSize: '12px' }}
                                     />
                                     <span className="p-inputgroup-addon">{formData.rows[0]?.Und || ''}</span>
                                 </div>
                             )}
                         />
-                        <Column field="lotNumbers" header="  Lot Info" body={(rowData, rowIndex) => (rowData.batch === 'Y' ? lotTemplate(rowData, rowIndex.rowIndex) : '')} />
+                        <Column field="lotNumbers" header={t('issueProductionVariety.lotInfo')} body={(rowData, rowIndex) => (rowData.batch === 'Y' ? lotTemplate(rowData, rowIndex.rowIndex) : '')} />
                         {/* <Column body={(rowData, rowIndex) => (rowData.batch === 'Y' ? <Button label="" icon="pi pi-plus" className="p-button-secondary" onClick={() => addLot(rowIndex.rowIndex)} /> : '')} /> */}
                     </DataTable>
                     {!pallet && ParentOrKid == 'Kid' && <div>{times}</div>}

--- a/components/Pallets/Pallets.jsx
+++ b/components/Pallets/Pallets.jsx
@@ -7,10 +7,12 @@ import { DataTable } from 'primereact/datatable';
 import { Column } from 'primereact/column';
 import { Toast } from 'primereact/toast';
 import EditProduction from '../EditProduction/EditProduction'
+import { useTranslation } from '../../utilities/i18n';
 
 const Pallets = ({ id, visible, onHide }) => {
     const [palletData, setPalletData] = useState([]);
     const toast = useRef(null);
+    const { t } = useTranslation();
     const [selectedRow, setSelectedRow] = useState(null);
     const [isEditDialogVisible, setEditDialogVisible] = useState(false);
 
@@ -45,7 +47,7 @@ const Pallets = ({ id, visible, onHide }) => {
             console.log(data)
         } catch (error) {
             console.error('Error fetching pallet data:', error);
-            toast.current.show({ severity: 'error', summary: 'Error', detail: 'Error fetching pallet data' });
+            toast.current.show({ severity: 'error', summary: t('error'), detail: t('pallets.errorFetching') });
         }
     };
 
@@ -62,10 +64,10 @@ const Pallets = ({ id, visible, onHide }) => {
             }
 
             const data = await response.json();
-            toast.current.show({ severity: 'success', summary: 'Success', detail: 'Label printed successfully' });
+            toast.current.show({ severity: 'success', summary: t('success'), detail: t('pallets.labelPrinted') });
         } catch (error) {
             console.error('Error printing label:', error);
-            toast.current.show({ severity: 'error', summary: 'Error', detail: 'Failed to print label' });
+            toast.current.show({ severity: 'error', summary: t('error'), detail: t('pallets.failedPrintLabel') });
         }
     };
 
@@ -103,7 +105,7 @@ const Pallets = ({ id, visible, onHide }) => {
 
     const footer = (
         <div className="p-d-flex p-jc-end">
-            <Button label="Close" icon="pi pi-times" className="p-button-danger" onClick={onHide} />
+            <Button label={t('pallets.close')} icon="pi pi-times" className="p-button-danger" onClick={onHide} />
         </div>
     );
 
@@ -116,11 +118,11 @@ const Pallets = ({ id, visible, onHide }) => {
                 refreshData={refreshData}
             />
             <Toast ref={toast} />
-            <Dialog maximizable header="Production Pallets" visible={visible} style={{ width: '90vw' }} footer={footer} onHide={onHide}>
+            <Dialog maximizable header={t('pallets.title')} visible={visible} style={{ width: '90vw' }} footer={footer} onHide={onHide}>
                 <DataTable value={palletData} scrollable style={{ 'fontSize': '10px' }} >
                     <Column
                         field="DATE"
-                        header="Date"
+                        header={t('pallets.date')}
                         body={(rowData) => {
                             const dateParts = rowData.DATE.split('-'); // Asumiendo que rowData.DATE está en formato 'YYYY-MM-DD'
                             const formattedDate = `${dateParts[1]}/${dateParts[2]}/${dateParts[0]}`; // 'MM/DD/YYYY'
@@ -139,25 +141,25 @@ const Pallets = ({ id, visible, onHide }) => {
                     />
 
 
-                    <Column field="LineShift" header="Line Shift" />
-                    <Column field="CustomerPO" header="Customer PO" />
-                    <Column field="SKU" header="SKU" />
-                    <Column field="ProducDesc" header="Prod. Description" />
-                    <Column field="No.Pallet" header="No. of Pallet" />
-                    <Column field="ID" header="No. of Pallet" />
+                    <Column field="LineShift" header={t('pallets.lineShift')} />
+                    <Column field="CustomerPO" header={t('pallets.customerPO')} />
+                    <Column field="SKU" header={t('pallets.sku')} />
+                    <Column field="ProducDesc" header={t('pallets.productDescription')} />
+                    <Column field="No.Pallet" header={t('pallets.noOfPallet')} />
+                    <Column field="ID" header={t('pallets.noOfPallet')} />
 
-                    <Column field="QTY PER PALLET" header="Cases per pallet" />
+                    <Column field="QTY PER PALLET" header={t('pallets.casesPerPallet')} />
                     {/* <Column field="LOT" header="LOT" /> */}
 
                     <Column
                         field="LOT"
-                        header="LOT"
+                        header={t('pallets.lot')}
                         body={(rowData) => rowData.NEWBATCH ? rowData.NEWBATCH : rowData.LOT}
                     />
 
                     <Column
                         field="BEST BEFORE"
-                        header="BestBuy"
+                        header={t('pallets.bestBefore')}
                         body={(rowData) => {
                             const bestBefore = rowData['BEST BEFORE'];
 
@@ -171,14 +173,14 @@ const Pallets = ({ id, visible, onHide }) => {
                             }
 
                             // Valor por defecto si no existe o no es válido
-                            return "N/A";
+                            return t('pallets.na');
                         }}
                     />
 
 
-                    <Column field="BIN LOCATION" header="Bin Location" />
-                    <Column body={actionTemplate} header="Print" />
-                    <Column body={edit} header="Edit" />
+                    <Column field="BIN LOCATION" header={t('pallets.binLocation')} />
+                    <Column body={actionTemplate} header={t('pallets.print')} />
+                    <Column body={edit} header={t('pallets.edit')} />
                 </DataTable>
             </Dialog>
 

--- a/components/ReceiptProductionVariety/ReceiptProductionVariety.jsx
+++ b/components/ReceiptProductionVariety/ReceiptProductionVariety.jsx
@@ -14,11 +14,13 @@ import uniqueCodePallet from '../../utilities/unique';
 //bacth logic
 
 import batchId from '../../utilities/batchid'
+import { useTranslation } from '../../utilities/i18n';
 
 const ReceiptProduction = ({ data, visible, onHide, numPallet }) => {
 
     const BASE_URL = process.env.NEXT_PUBLIC_API_UR;
     const API = process.env.API
+    const { t } = useTranslation();
 
     const [inputBatch, setiInputBatch] = useState('');
     const [inputBestBefore, setInputBestBefore] = useState('');
@@ -156,7 +158,7 @@ const ReceiptProduction = ({ data, visible, onHide, numPallet }) => {
                 setBinLocations(formattedBins);
             } catch (error) {
                 console.error('Error fetching bin locations:', error);
-                toast.current.show({ severity: 'error', summary: 'Error', detail: 'Failed to fetch bin locations' });
+                toast.current.show({ severity: 'error', summary: t('error'), detail: t('receiptProductionVariety.failedBinLocations') });
             }
         }
     };
@@ -225,7 +227,7 @@ const ReceiptProduction = ({ data, visible, onHide, numPallet }) => {
             return doughReceptionPayload;
         } catch (error) {
             console.error('Error fetching dough reception data:', error);
-            toast.current.show({ severity: 'error', summary: 'Error', detail: 'Failed to fetch dough reception data' });
+            toast.current.show({ severity: 'error', summary: t('error'), detail: t('receiptProductionVariety.failedDoughReception') });
         }
     };
 
@@ -345,7 +347,7 @@ const ReceiptProduction = ({ data, visible, onHide, numPallet }) => {
         if (!inputBatch) { 
 
            
-            toast.current.show({ severity: 'error', summary: 'Missing Data', detail: 'Batch number is required. Please set it before proceeding.' });
+            toast.current.show({ severity: 'error', summary: t('receiptProductionVariety.missingData'), detail: t('receiptProductionVariety.batchRequired') });
             setLoading(false);
             return; 
         }
@@ -355,7 +357,7 @@ const ReceiptProduction = ({ data, visible, onHide, numPallet }) => {
         if (!inputBestBefore) { 
 
            
-            toast.current.show({ severity: 'error', summary: 'Missing Data', detail: 'BestBefore is required. Please set it before proceeding.' });
+            toast.current.show({ severity: 'error', summary: t('receiptProductionVariety.missingData'), detail: t('receiptProductionVariety.bestBeforeRequired') });
             setLoading(false);
             return; 
         }
@@ -395,7 +397,7 @@ const ReceiptProduction = ({ data, visible, onHide, numPallet }) => {
                 console.log(pallets)
                 await postDocument(`${BASE_URL}/Production/PostArtSNPallets`, pallets, token, 'Pallet');
 
-                toast.current.show({ severity: 'success', summary: 'Success', detail: 'All documents created successfully' });
+                toast.current.show({ severity: 'success', summary: t('success'), detail: t('receiptProductionVariety.documentsCreated') });
                 onHide();
                 setFormData({
                     warehouse: data.warehouse,
@@ -420,10 +422,10 @@ const ReceiptProduction = ({ data, visible, onHide, numPallet }) => {
             else if (data.ProduccionGO !== 'Y') {
 
                 if (!receiptResult) {
-                    toast.current.show({ severity: 'error', summary: 'Error', detail: 'An unexpected error occurblack' });
+                    toast.current.show({ severity: 'error', summary: t('error'), detail: t('receiptProductionVariety.unexpectedError') });
                 }
                 else {
-                    toast.current.show({ severity: 'success', summary: 'Success', detail: 'All documents created successfully' });
+                    toast.current.show({ severity: 'success', summary: t('success'), detail: t('receiptProductionVariety.documentsCreated') });
                     onHide();
                    
 
@@ -449,7 +451,7 @@ const ReceiptProduction = ({ data, visible, onHide, numPallet }) => {
             }
         } catch (error) {
             console.error('Error:', error);
-            toast?.current?.show({ severity: 'error', summary: 'Error', detail: 'An unexpected error occurblack' });
+            toast?.current?.show({ severity: 'error', summary: t('error'), detail: t('receiptProductionVariety.unexpectedError') });
         } finally {
             setLoading(false);
         }
@@ -470,7 +472,7 @@ const ReceiptProduction = ({ data, visible, onHide, numPallet }) => {
 
             if (!response.ok) {
                 console.log(result)
-                toast.current.show({ severity: 'error', summary: `${docType} Error`, detail: result.Message });
+                toast.current.show({ severity: 'error', summary: `${docType} ${t('error')}`, detail: result.Message });
                 return null;
             }
 
@@ -479,7 +481,7 @@ const ReceiptProduction = ({ data, visible, onHide, numPallet }) => {
            
         } catch (error) {
             console.error(`Error creating ${docType}:`, error);
-            toast.current.show({ severity: 'error', summary: `${docType} Error`, detail: 'An unexpected error occurblack' });
+            toast.current.show({ severity: 'error', summary: `${docType} ${t('error')}`, detail: t('receiptProductionVariety.unexpectedError') });
             return null;
         }
     };
@@ -558,7 +560,7 @@ const ReceiptProduction = ({ data, visible, onHide, numPallet }) => {
     const footer = (
         <div >
             {/* <Button label="Cancel" icon="pi pi-times" className="p-button-danger p-mr-2" onClick={onHide} /> */}
-            <Button label="Save & Print" icon="pi pi-check"
+            <Button label={t('receiptProductionVariety.savePrint')} icon="pi pi-check"
                 className="p-button-success"
                 style={{ marginLeft: '0.5em' }}
                 onClick={handleSubmit}
@@ -568,7 +570,7 @@ const ReceiptProduction = ({ data, visible, onHide, numPallet }) => {
     return (
         <>
             <Toast ref={toast} position="top-right" style={{ marginTop: '60px', zIndex: 9999 }} />
-            <Dialog header="Product Reception" visible={visible} onHide={onHide} footer={footer} closable={false} style={{ width: '80vh' }}>
+            <Dialog header={t('receiptProductionVariety.productReception')} visible={visible} onHide={onHide} footer={footer} closable={false} style={{ width: '80vh' }}>
                 <Card>
                     <div className="p-fluid">
                         {loading && (
@@ -579,12 +581,12 @@ const ReceiptProduction = ({ data, visible, onHide, numPallet }) => {
                         <div className='final-product' style={styles.productInfo}>
                             <div className="p-grid p-align-center" style={{ 'display': 'flex' }}>
                                 <div className="p-col-4 p-md-2" style={styles.labelColumn}>
-                                    <label htmlFor="po" style={styles.label}>PO: </label>
-                                    <label htmlFor="sku" style={styles.label}>SKU: </label>
-                                    <label htmlFor="lot" style={styles.label}>LOT: </label>
-                                    <label htmlFor="bestBefore" style={styles.label}>BEST BEFORE: </label>
-                                    <label htmlFor="palletX" style={styles.label}>No PALLETS: </label>
-                                    <label htmlFor="casePerPallet" style={styles.label}>CASES PER PALLET: </label>
+                                    <label htmlFor="po" style={styles.label}>{t('receiptProductionVariety.po')}: </label>
+                                    <label htmlFor="sku" style={styles.label}>{t('receiptProductionVariety.sku')}: </label>
+                                    <label htmlFor="lot" style={styles.label}>{t('receiptProductionVariety.lot')}: </label>
+                                    <label htmlFor="bestBefore" style={styles.label}>{t('receiptProductionVariety.bestBefore')}: </label>
+                                    <label htmlFor="palletX" style={styles.label}>{t('receiptProductionVariety.noPallets')}: </label>
+                                    <label htmlFor="casePerPallet" style={styles.label}>{t('receiptProductionVariety.casesPerPallet')}: </label>
                                 </div>
                                 <div className="p-col-8 p-md-10" style={styles.valueColumn}>
                                     <InputText disabled style={styles.text} value={data?.PO || ''} />

--- a/pages/productionVariety/[id].jsx
+++ b/pages/productionVariety/[id].jsx
@@ -22,6 +22,7 @@ import combineDateAndTime from '../../utilities/functions';
 import substractTime from '../../utilities/timeBack'
 import { ProgressSpinner } from 'primereact/progressspinner';
 import formatNumber from '../../utilities/formatNumber';
+import { useTranslation } from '../../utilities/i18n';
 const ProductionOrder = () => {
 
   const router = useRouter();
@@ -41,7 +42,8 @@ const ProductionOrder = () => {
   const [restarTime, setRestarTime] = useState(null);
   const [enable, setEnable] = useState(false);
   const toast = useRef(null);
-  const [textWarning, setTextWarning] = useState('Are you sure you want to finalize the production? Once the Production Order is closed, you will no longer be able to add new mixes or receive finished goods. If you agree, click OK; otherwise, click Cancel');
+  const { t } = useTranslation();
+  const [textWarning, setTextWarning] = useState(t('productionPage.finalizeConfirmation'));
   const [isWarningVisible, setIsWarningVisible] = useState(false);
   const [isSaved, setIsSaved] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -111,8 +113,8 @@ const ProductionOrder = () => {
       if (!isValid) {
           toast.current.show({
               severity: 'warn',
-              summary: 'Warning',
-              detail: 'Some components have not been issued. Please review the components related to seasoning/oil.'
+              summary: t('warning'),
+              detail: t('productionPage.someComponentsNotIssued')
           });
       }
   
@@ -317,15 +319,15 @@ const ProductionOrder = () => {
       const result = await response.json();
 
       if (response.ok) {
-        toast.current.show({ severity: 'success', summary: 'Success', detail: 'Production paused successfully' });
+        toast.current.show({ severity: 'success', summary: t('success'), detail: t('productionPage.productionPaused') });
         setPauseTime(elapsedFormatted);
 
       } else {
-        toast.current.show({ severity: 'error', summary: 'Error', detail: result.message || 'An unexpected error occurred' });
+        toast.current.show({ severity: 'error', summary: t('error'), detail: result.message || t('productionInfo.unknownError') });
       }
     } catch (error) {
       console.error('Error pausing production:', error);
-      toast.current.show({ severity: 'error', summary: 'Error', detail: 'Failed to pause production' });
+      toast.current.show({ severity: 'error', summary: t('error'), detail: t('productionPage.productionPauseFailed') });
     }
 
 
@@ -365,14 +367,14 @@ const ProductionOrder = () => {
         const result = await response.json();
 
         if (response.ok) {
-          toast.current.show({ severity: 'success', summary: 'Success', detail: 'Production resumed successfully' });
+          toast.current.show({ severity: 'success', summary: t('success'), detail: t('productionPage.productionResumed') });
 
         } else {
-          toast.current.show({ severity: 'error', summary: 'Error', detail: result.message || 'An unexpected error occurred' });
+          toast.current.show({ severity: 'error', summary: t('error'), detail: result.message || t('productionInfo.unknownError') });
         }
       } catch (error) {
         console.error('Error resuming production:', error);
-        toast.current.show({ severity: 'error', summary: 'Error', detail: 'Failed to resume production' });
+        toast.current.show({ severity: 'error', summary: t('error'), detail: t('productionPage.productionResumeFailed') });
       }
 
       setRestarTime(substractTime(order[0].ConsumedTime))
@@ -413,13 +415,13 @@ const ProductionOrder = () => {
         const result = await response.json();
 
         if (response.ok) {
-          toast.current.show({ severity: 'success', summary: 'Success', detail: 'Production started successfully' });
+          toast.current.show({ severity: 'success', summary: t('success'), detail: t('productionPage.productionStarted') });
         } else {
-          toast.current.show({ severity: 'error', summary: 'Error', detail: result.message || 'An unexpected error occurred' });
+          toast.current.show({ severity: 'error', summary: t('error'), detail: result.message || t('productionInfo.unknownError') });
         }
       } catch (error) {
         console.error('Error starting production:', error);
-        toast.current.show({ severity: 'error', summary: 'Error', detail: 'Failed to start production' });
+        toast.current.show({ severity: 'error', summary: t('error'), detail: t('productionPage.productionStartFailed') });
       }
       finally {
         setLoadingStart(false)
@@ -468,12 +470,12 @@ const ProductionOrder = () => {
       await Promise.all(promises);
   
       // Mostrar un solo mensaje de éxito cuando todas las órdenes se hayan cerrado correctamente
-      toast.current.show({ severity: 'success', summary: 'Success', detail: 'All production orders closed successfully' });
-  
+      toast.current.show({ severity: 'success', summary: t('success'), detail: t('productionPage.allOrdersClosed') });
+
       fetchOrder(); // Actualiza los datos después de cerrar las órdenes
     } catch (error) {
       console.error('Error closing production orders:', error);
-      toast.current.show({ severity: 'error', summary: 'Error', detail: 'Failed to close production orders' });
+      toast.current.show({ severity: 'error', summary: t('error'), detail: t('productionPage.closeOrdersFailed') });
     } finally {
       setLoading(false);
     }
@@ -588,7 +590,7 @@ const ProductionOrder = () => {
       
         showIssueDialog(order);
       } else {
-        toast.current.show({ severity: 'warn', summary: 'Warning', detail: 'There is not enough dough quantity to continue generating pallets. Please complete mixes.' });
+        toast.current.show({ severity: 'warn', summary: t('warning'), detail: t('productionPage.notEnoughDough') });
 
       }
     } else {
@@ -676,7 +678,7 @@ const ProductionOrder = () => {
       <>
         {rowData.Type === 'PO' && (
           <Button
-            label={order[0].CloseDate || order[0].IsPaused === 'Y' ? "Review" : "Produce"}
+            label={order[0].CloseDate || order[0].IsPaused === 'Y' ? t('productionPage.review') : t('productionOrder.produce')}
             className="p-button-info"
             onClick={() => handleProduceClick(rowData)}
             disabled={order[0].CloseDate ? false : (!order[0].StartTime || order[0].CloseDate)}
@@ -685,7 +687,7 @@ const ProductionOrder = () => {
         )}
         {rowData.Type === 'Item' && (
           <Button
-            label="Issue"
+            label={t('productionOrder.issue')}
             className="p-button-warning"
             onClick={() => showIssueDialog(rowData)}
             disabled={!order[0].StartTime || order[0].CloseDate}
@@ -701,7 +703,7 @@ const ProductionOrder = () => {
   return (
     <div>
       <Toast ref={toast} position="top-right" style={{ marginTop: '60px', zIndex: 9999 }} />
-      <Card title={<span><BackButton /> Production Order </span>} className="p-card">
+      <Card title={<span><BackButton /> {t('productionOrder.title')} </span>} className="p-card">
       {loadingStart && (
                     <div className="p-d-flex p-jc-center p-ai-center" style={{ marginTop: '1rem' }}>
                         <ProgressSpinner style={{ width: '50px', height: '50px' }} />
@@ -709,23 +711,23 @@ const ProductionOrder = () => {
                 )}
         <div className="header-prod">
           <div className="p-col-12 p-md-6">
-          <div><b>Customer PO:</b> {order[0]?.CustomerPO}</div>
-           
-            <div><b>Product No.:</b> {order[0]?.ItemCode}</div>
-            <div><b>Product Description:</b> {order[0]?.ProdName}</div>
-            {order[0]?.ParentOrKid==='Parent'&& <div><b>Planned Quantity:</b>  {formatNumber(Number(order[0]?.PlannedQty))} EA ({Math.ceil(formatNumber(Number(order[0]?.PlannedQty))/order[0].UndXPallet)} Pallets)</div>}
+          <div><b>{t('productionList.customerPO')}:</b> {order[0]?.CustomerPO}</div>
 
-            <div><b>Warehouse:</b> {order[0]?.Warehouse}</div>
-            <div><b>Best Buy Date:</b> {formatDate(addDaysToDate(new Date(), order[0]?.BestBeforeDays))}</div>
+            <div><b>{t('productionOrder.productNo')}:</b> {order[0]?.ItemCode}</div>
+            <div><b>{t('productionOrder.productDescription')}:</b> {order[0]?.ProdName}</div>
+            {order[0]?.ParentOrKid==='Parent'&& <div><b>{t('productionOrder.plannedQuantity')}:</b>  {formatNumber(Number(order[0]?.PlannedQty))} EA ({Math.ceil(formatNumber(Number(order[0]?.PlannedQty))/order[0].UndXPallet)} {t('productionList.pallets')})</div>}
+
+            <div><b>{t('productionOrder.warehouse')}:</b> {order[0]?.Warehouse}</div>
+            <div><b>{t('productionPage.bestBuyDate')}:</b> {formatDate(addDaysToDate(new Date(), order[0]?.BestBeforeDays))}</div>
           </div>
           <div className="p-col-12 p-md-6">
-          <div><b>Status:</b> {order[0]?.Status}</div>
-           
-            <div><b>Delivery Date:</b> {new Date(order[0]?.DeliveryDate).toLocaleDateString('en-US', options)}</div>
-            {!allItems && <div><b>Start Date:</b> {order[0]?.StartDate ? new Date(order[0]?.StartDate).toLocaleDateString('en-US', options) : ''}</div>}
-            {!allItems && <div><b>Finish Date:</b> {order[0]?.DueDate ? new Date(order[0]?.DueDate).toLocaleDateString('en-US', options) : ''}</div>}
-            <div><b>No. (PO):</b> {order[0]?.DocNum}</div>
-            {allItems&&<div style={{'color':'#007ad9' , 'padding-top':'1rem', 'fontSize':'24px'}}><b>{order[0]?.TypeDetail === 'Pallets' ? "#Pallets "+ line +' '+ shift +':': "#Mixes "+line +' '+ shift +':'}</b>  { (order[0]?.TypeDetail === 'Mixes' ?  (mixesByShift === null ?0 :mixesByShift) : palletByShift)}</div>}
+          <div><b>{t('productionList.status')}:</b> {order[0]?.Status}</div>
+
+            <div><b>{t('productionPage.deliveryDate')}:</b> {new Date(order[0]?.DeliveryDate).toLocaleDateString('en-US', options)}</div>
+            {!allItems && <div><b>{t('productionOrder.startDate')}:</b> {order[0]?.StartDate ? new Date(order[0]?.StartDate).toLocaleDateString('en-US', options) : ''}</div>}
+            {!allItems && <div><b>{t('productionOrder.finishDate')}:</b> {order[0]?.DueDate ? new Date(order[0]?.DueDate).toLocaleDateString('en-US', options) : ''}</div>}
+            <div><b>{t('productionOrder.poNumber')}:</b> {order[0]?.DocNum}</div>
+            {allItems&&<div style={{'color':'#007ad9' , 'padding-top':'1rem', 'fontSize':'24px'}}><b>{order[0]?.TypeDetail === 'Pallets' ? `#${t('productionList.pallets')} ${line} ${shift}:` : `#${t('productionList.mixes')} ${line} ${shift}:`}</b>  { (order[0]?.TypeDetail === 'Mixes' ?  (mixesByShift === null ?0 :mixesByShift) : palletByShift)}</div>}
 
            
           </div>
@@ -742,10 +744,10 @@ const ProductionOrder = () => {
              <div className="production-buttons">
               {allItems && (
                 <>
-                  {!order[0]?.StartTime && <Button label="Start" icon="pi pi-play" className="p-button-success p-mr-2" onClick={handleStartProduction} disabled={!!startTime || order[0]?.StartTime} rounded />}
-                  <Button label="Close PO" icon="pi-stop-circle" className="p-button-danger" onClick={handleEndProductionClick} disabled={!order[0]?.StartTime || order[0].CloseDate} rounded />
-                  {order[0]?.IsPaused === 'N' && order[0]?.StartTime && <Button label="Pause" icon="pi pi-pause" className="p-button font-bold" onClick={handlePauseProduction} disabled={order[0]?.IsPaused === 'Y' || order[0].CloseDate} rounded />}
-                  {order[0]?.IsPaused === 'Y' && <Button label="Resume" icon="pi-reply" onClick={handleResumeProduction} disabled={order[0]?.IsPaused === 'N' || order[0].CloseDate} rounded style={{ backgroundColor: '#2196F3', borderColor: '#2196F3', color: '#fff' }} />}
+                  {!order[0]?.StartTime && <Button label={t('productionPage.start')} icon="pi pi-play" className="p-button-success p-mr-2" onClick={handleStartProduction} disabled={!!startTime || order[0]?.StartTime} rounded />}
+                  <Button label={t('productionOrder.closePO')} icon="pi-stop-circle" className="p-button-danger" onClick={handleEndProductionClick} disabled={!order[0]?.StartTime || order[0].CloseDate} rounded />
+                  {order[0]?.IsPaused === 'N' && order[0]?.StartTime && <Button label={t('productionPage.pause')} icon="pi pi-pause" className="p-button font-bold" onClick={handlePauseProduction} disabled={order[0]?.IsPaused === 'Y' || order[0].CloseDate} rounded />}
+                  {order[0]?.IsPaused === 'Y' && <Button label={t('productionPage.resume')} icon="pi-reply" onClick={handleResumeProduction} disabled={order[0]?.IsPaused === 'N' || order[0].CloseDate} rounded style={{ backgroundColor: '#2196F3', borderColor: '#2196F3', color: '#fff' }} />}
                 </>
               )}
             </div>
@@ -759,7 +761,7 @@ const ProductionOrder = () => {
               <div className='production-buttons'>
                 {/* {order[0].ProduccionGO !== 'Y' && <Button label="Product Reception" className="p-button-danger" onClick={showBatchDialog} disabled={order[0].CloseDate}  rounded/>} */}
                 <Button
-                  label={order[0]?.TypeDetail === 'Pallets' ? "Add Pallet" : "Add Mix"}
+                  label={order[0]?.TypeDetail === 'Pallets' ? t('productionPage.addPallet') : t('productionPage.addMix')}
                   className="p-button-success p-mr-2"
                   onClick={() => handleButtonClick(order)}
                   disabled={
@@ -797,21 +799,21 @@ const ProductionOrder = () => {
           </div>)}
         </div>
       </Card>
-      <Card title="Components" className="p-card p-mt-3">
+      <Card title={t('productionOrder.components')} className="p-card p-mt-3">
         <div className="p-datatable-wrapper">
           <DataTable value={order} paginator rows={10} scrollable scrollHeight="400px">
-            {/* <Column field="Type" header="Type" /> */}
-            <Column field="ItemCode2" header="Product" />
-            <Column field="ItemName" header="Description" />
+            {/* <Column field="Type" header={t('productionOrder.type')} /> */}
+            <Column field="ItemCode2" header={t('productionOrder.product')} />
+            <Column field="ItemName" header={t('productionOrder.productDescription')} />
             {/* {allItems &&<Column field="Und" header="Und" />} */}
-            <Column field="BaseQtyLine" header="Base Quantity" body={(rowData) => formatNumber(parseFloat(rowData.BaseQtyLine))} />
-            <Column field="PlannedQtyLine" header="Planned" body={(rowData) => formatNumber(parseFloat(rowData.PlannedQtyLine))} />
+            <Column field="BaseQtyLine" header={t('productionOrder.baseQuantity')} body={(rowData) => formatNumber(parseFloat(rowData.BaseQtyLine))} />
+            <Column field="PlannedQtyLine" header={t('productionOrder.planned')} body={(rowData) => formatNumber(parseFloat(rowData.PlannedQtyLine))} />
 
             {/* <Column field="Available" header="Available" body={(rowData) => parseFloat(rowData.Available).toFixed(3)} /> */}
-            {!allItems && <Column field="QtyChildrenCmpl" header="Produced" body={(rowData) => formatNumber(parseFloat(rowData.QtyChildrenCmpl || 0))} />}
-            <Column field="IssuedQty" header="Issued" body={(rowData) => formatNumber(parseFloat(rowData.IssuedQty))} />
-            {!allItems && <Column field="POChildrenDocNum" header="Child PO" />}
-            {!allItems && <Column body={actionTemplate} header="Actions" />}
+            {!allItems && <Column field="QtyChildrenCmpl" header={t('productionOrder.produced')} body={(rowData) => formatNumber(parseFloat(rowData.QtyChildrenCmpl || 0))} />}
+            <Column field="IssuedQty" header={t('productionOrder.issued')} body={(rowData) => formatNumber(parseFloat(rowData.IssuedQty))} />
+            {!allItems && <Column field="POChildrenDocNum" header={t('productionOrder.childPO')} />}
+            {!allItems && <Column body={actionTemplate} header={t('productionOrder.actions')} />}
 
 
           </DataTable>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -94,6 +94,7 @@
     "linkedOrder": "Linked Order",
     "salesOrder": "Sales Order",
     "closeOrder": "Close Order",
+    "closePO": "Close PO",
     "addBatch": "Add Batch",
     "components": "Components",
     "type": "Type",
@@ -126,7 +127,9 @@
     "resume": "Resume",
     "addPallet": "Add Pallet",
     "addMix": "Add Mix",
-    "deliveryDate": "Delivery Date"
+    "deliveryDate": "Delivery Date",
+    "bestBuyDate": "Best Buy Date",
+    "start": "Start"
   },
   "productionList": {
     "orders": "Production Orders",
@@ -148,6 +151,63 @@
     "statusClose": "Close",
     "group": "Group",
     "ungroup": "Ungroup"
+  },
+  "issueProductionVariety": {
+    "dryMixTime": "Dry Mix Time:",
+    "wetMixTime": "Wet Mix Time:",
+    "timePlaceholder": "time",
+    "minutes": "min",
+    "mixTimesRequired": "Wet Mix Time and Dry Mix Time are required.",
+    "real": "Real",
+    "quantity": "Quantity",
+    "lotInfo": "Lot Info",
+    "lotQtyZero": "Lot quantities cannot be zero.",
+    "qtyZero": "The quantities cannot be zero.",
+    "exceedAvailable": "The quantity cannot exceed the total available in the selected lots.",
+    "lotRequired": "All batch items must have a selected lot.",
+    "issueComponents": "Issue Components",
+    "full": "Full",
+    "half": "Half",
+    "double": "Double"
+  },
+  
+  "receiptProductionVariety": {
+    "savePrint": "Save & Print",
+    "productReception": "Product Reception",
+    "po": "PO",
+    "sku": "SKU",
+    "lot": "LOT",
+    "bestBefore": "BEST BEFORE",
+    "noPallets": "No PALLETS",
+    "casesPerPallet": "CASES PER PALLET",
+    "failedBinLocations": "Failed to fetch bin locations",
+    "failedDoughReception": "Failed to fetch dough reception data",
+    "batchRequired": "Batch number is required. Please set it before proceeding.",
+    "bestBeforeRequired": "BestBefore is required. Please set it before proceeding.",
+    "documentsCreated": "All documents created successfully",
+    "unexpectedError": "An unexpected error occurred",
+    "missingData": "Missing Data"
+  },
+
+  "pallets": {
+    "errorFetching": "Error fetching pallet data",
+    "labelPrinted": "Label printed successfully",
+    "failedPrintLabel": "Failed to print label",
+    "close": "Close",
+    "title": "Production Pallets",
+    "date": "Date",
+    "lineShift": "Line Shift",
+    "customerPO": "Customer PO",
+    "sku": "SKU",
+    "productDescription": "Prod. Description",
+    "noOfPallet": "No. of Pallet",
+    "casesPerPallet": "Cases per pallet",
+    "lot": "LOT",
+    "bestBefore": "BestBuy",
+    "na": "N/A",
+    "binLocation": "Bin Location",
+    "print": "Print",
+    "edit": "Edit"
   },
   "downTime": {
     "title": "Down Time",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -94,6 +94,7 @@
     "linkedOrder": "Orden Vinculada",
     "salesOrder": "Orden de Venta",
     "closeOrder": "Cerrar Orden",
+    "closePO": "Cerrar OP",
     "addBatch": "Agregar Lote",
     "components": "Componentes",
     "type": "Tipo",
@@ -126,7 +127,9 @@
     "resume": "Reanudar",
     "addPallet": "Agregar Pallet",
     "addMix": "Agregar Mezcla",
-    "deliveryDate": "Fecha de entrega"
+    "deliveryDate": "Fecha de entrega",
+    "bestBuyDate": "Fecha de consumo preferente",
+    "start": "Iniciar"
   },
   "productionList": {
     "orders": "Órdenes de Producción",
@@ -148,6 +151,63 @@
     "statusClose": "Cerrado",
     "group": "Agrupar",
     "ungroup": "Desagrupar"
+  },
+  "issueProductionVariety": {
+    "dryMixTime": "Tiempo de mezcla seca:",
+    "wetMixTime": "Tiempo de mezcla húmeda:",
+    "timePlaceholder": "tiempo",
+    "minutes": "min",
+    "mixTimesRequired": "Se requieren los tiempos de mezcla húmeda y seca.",
+    "real": "Real",
+    "quantity": "Cantidad",
+    "lotInfo": "Información de lote",
+    "lotQtyZero": "Las cantidades de lote no pueden ser cero.",
+    "qtyZero": "Las cantidades no pueden ser cero.",
+    "exceedAvailable": "La cantidad no puede exceder el total disponible en los lotes seleccionados.",
+    "lotRequired": "Todos los artículos con lote deben tener un lote seleccionado.",
+    "issueComponents": "Emitir Componentes",
+    "full": "Completa",
+    "half": "Media",
+    "double": "Doble"
+  },
+
+  "receiptProductionVariety": {
+    "savePrint": "Guardar e Imprimir",
+    "productReception": "Recepción de Producto",
+    "po": "OP",
+    "sku": "SKU",
+    "lot": "LOTE",
+    "bestBefore": "FECHA DE CONSUMO",
+    "noPallets": "No PALLETS",
+    "casesPerPallet": "CAJAS POR PALLET",
+    "failedBinLocations": "Error al obtener ubicaciones de almacén",
+    "failedDoughReception": "Error al obtener datos de recepción de masa",
+    "batchRequired": "El número de lote es obligatorio. Establézcalo antes de continuar.",
+    "bestBeforeRequired": "La fecha de consumo es obligatoria. Establézcala antes de continuar.",
+    "documentsCreated": "Todos los documentos creados correctamente",
+    "unexpectedError": "Ocurrió un error inesperado",
+    "missingData": "Datos faltantes"
+  },
+
+  "pallets": {
+    "errorFetching": "Error al obtener datos de pallets",
+    "labelPrinted": "Etiqueta impresa correctamente",
+    "failedPrintLabel": "Error al imprimir la etiqueta",
+    "close": "Cerrar",
+    "title": "Pallets de Producción",
+    "date": "Fecha",
+    "lineShift": "Turno de Línea",
+    "customerPO": "PO del Cliente",
+    "sku": "SKU",
+    "productDescription": "Descripción del Prod.",
+    "noOfPallet": "No. de Pallet",
+    "casesPerPallet": "Cajas por pallet",
+    "lot": "LOTE",
+    "bestBefore": "Mejor antes",
+    "na": "N/A",
+    "binLocation": "Ubicación en Bin",
+    "print": "Imprimir",
+    "edit": "Editar"
   },
   "downTime": {
     "title": "Tiempo Muerto",


### PR DESCRIPTION
## Summary
- add i18n hooks and translation keys for production variety page
- localize issue, receipt, and pallet dialogs
- provide English and Spanish strings for new messages

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (terminated after startup)

------
https://chatgpt.com/codex/tasks/task_e_68b4b38614808325891309eb9cd95112