### PR TITLE
Fix common translation files

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -292,7 +292,7 @@
     "errorSendingPallets": "Error sending the Pallets.",
     "allDocsSuccess": "All documents were created successfully.",
     "unexpectedError": "An unexpected error occurred."
-
+  },
 
   "report": {
     "typeLabels": {
@@ -330,6 +330,7 @@
       "effectiveDate": "Effective Date",
       "confidential": "Confidential"
     }
+  },
 
   "waste": {
     "title": "Waste Register",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -292,7 +292,7 @@
     "errorSendingPallets": "Error al enviar los Pallets.",
     "allDocsSuccess": "Todos los documentos fueron creados correctamente.",
     "unexpectedError": "Ocurrió un error inesperado."
-
+  },
 
   "report": {
     "typeLabels": {
@@ -330,8 +330,9 @@
       "effectiveDate": "Fecha Efectiva",
       "confidential": "Confidencial"
     }
+  },
 
-  "waste": {
+    "waste": {
     "title": "Registro de Desperdicio",
     "reason": "Motivo",
     "remarks": "Comentarios",


### PR DESCRIPTION
## Summary
- fix structure in English `common.json`
- fix structure in Spanish `common.json`

## Testing
- `jq . public/locales/en/common.json`
- `jq . public/locales/es/common.json`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(starts server and exits when interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b76ff02883258a79c3cf3873c29b